### PR TITLE
Add AuthUser interface type

### DIFF
--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { User, Mail, Lock, Eye, EyeOff } from 'lucide-react';
 import { supabase } from '../lib/supabase';
+import type { AuthUser } from '../hooks/useAuth';
 
 interface AuthFormProps {
-  onAuthSuccess: (user: any) => void;
+  onAuthSuccess: (user: AuthUser) => void;
 }
 
 export function AuthForm({ onAuthSuccess }: AuthFormProps) {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
 import { User } from '@supabase/supabase-js';
 
-interface AuthUser {
+export interface AuthUser {
   id: string;
   email: string;
   username: string;


### PR DESCRIPTION
## Summary
- export `AuthUser` from `useAuth` hook
- update `AuthForm` props to use `AuthUser`

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6855997849bc8327a8214a8949de59c9