### PR TITLE
Fix lint import

### DIFF
--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { LogOut, User, UserCircle, Users, MessageCircle, Menu, X } from 'lucide-react';
+import { LogOut, UserCircle, Users, MessageCircle, Menu, X } from 'lucide-react';
 
 type PageType = 'group-chat' | 'dms' | 'profile';
 


### PR DESCRIPTION
## Summary
- remove unused `User` icon from ChatHeader import

## Testing
- `npm install`
- `npm run lint`
- `npx eslint src/components/ChatHeader.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6855997f87b0832782fab327d6a737bb