### PR TITLE
Fix types for supabase

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -76,19 +76,19 @@ export interface Database {
         Row: {
           id: string;
           user_id: string | null;
-          subscription: any;
+          subscription: Record<string, unknown>;
           created_at: string | null;
         };
         Insert: {
           id?: string;
           user_id?: string | null;
-          subscription: any;
+          subscription: Record<string, unknown>;
           created_at?: string | null;
         };
         Update: {
           id?: string;
           user_id?: string | null;
-          subscription?: any;
+          subscription?: Record<string, unknown>;
           created_at?: string | null;
         };
       };
@@ -99,7 +99,7 @@ export interface Database {
           user2_id: string;
           user1_username: string;
           user2_username: string;
-          messages: any | null;
+          messages: Record<string, unknown>[] | null;
           created_at: string | null;
           updated_at: string | null;
         };
@@ -109,7 +109,7 @@ export interface Database {
           user2_id: string;
           user1_username: string;
           user2_username: string;
-          messages?: any | null;
+          messages?: Record<string, unknown>[] | null;
           created_at?: string | null;
           updated_at?: string | null;
         };
@@ -119,7 +119,7 @@ export interface Database {
           user2_id?: string;
           user1_username?: string;
           user2_username?: string;
-          messages?: any | null;
+          messages?: Record<string, unknown>[] | null;
           created_at?: string | null;
           updated_at?: string | null;
         };


### PR DESCRIPTION
## Summary
- refine `subscription` and `messages` types

## Testing
- `npm run lint` *(fails: no-unused-vars)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685599be49348327a60c7a1daa861901