### PR TITLE
Add DM notification indicators

### DIFF
--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -9,9 +9,10 @@ interface ChatHeaderProps {
   onShowProfile: () => void;
   currentPage: PageType;
   onPageChange: (page: PageType) => void;
+  hasUnreadDMs?: boolean;
 }
 
-export function ChatHeader({ userName, onClearUser, onShowProfile, currentPage, onPageChange }: ChatHeaderProps) {
+export function ChatHeader({ userName, onClearUser, onShowProfile, currentPage, onPageChange, hasUnreadDMs }: ChatHeaderProps) {
   const [showMenu, setShowMenu] = useState(false);
   const [showMobileNav, setShowMobileNav] = useState(false);
 
@@ -52,7 +53,7 @@ export function ChatHeader({ userName, onClearUser, onShowProfile, currentPage, 
             
             <button
               onClick={() => onPageChange('dms')}
-              className={`flex items-center gap-2 px-3 py-2 rounded-lg transition-all ${
+              className={`relative flex items-center gap-2 px-3 py-2 rounded-lg transition-all ${
                 currentPage === 'dms'
                   ? 'bg-gray-600 text-white shadow-lg'
                   : 'text-gray-300 hover:text-white hover:bg-gray-700'
@@ -60,6 +61,9 @@ export function ChatHeader({ userName, onClearUser, onShowProfile, currentPage, 
               title="Direct Messages"
             >
               <MessageCircle className="w-5 h-5" />
+              {hasUnreadDMs && currentPage !== 'dms' && (
+                <span className="absolute -top-1 -right-1 block w-2 h-2 bg-red-500 rounded-full" />
+              )}
               <span className="text-sm font-medium">DMs</span>
             </button>
           </div>
@@ -67,9 +71,12 @@ export function ChatHeader({ userName, onClearUser, onShowProfile, currentPage, 
           {/* Mobile Navigation Toggle */}
           <button
             onClick={() => setShowMobileNav(!showMobileNav)}
-            className="md:hidden p-2 text-gray-300 hover:text-white hover:bg-gray-700 rounded-lg transition-colors ml-2"
+            className="relative md:hidden p-2 text-gray-300 hover:text-white hover:bg-gray-700 rounded-lg transition-colors ml-2"
           >
             {showMobileNav ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
+            {hasUnreadDMs && currentPage !== 'dms' && !showMobileNav && (
+              <span className="absolute -top-1 -right-1 block w-2 h-2 bg-red-500 rounded-full" />
+            )}
           </button>
         </div>
         
@@ -150,7 +157,12 @@ export function ChatHeader({ userName, onClearUser, onShowProfile, currentPage, 
                   : 'text-gray-300 hover:text-white hover:bg-gray-700'
               }`}
             >
-              <MessageCircle className="w-5 h-5" />
+              <div className="relative">
+                <MessageCircle className="w-5 h-5" />
+                {hasUnreadDMs && currentPage !== 'dms' && (
+                  <span className="absolute -top-1 -right-1 block w-2 h-2 bg-red-500 rounded-full" />
+                )}
+              </div>
               <span className="font-medium">Direct Messages</span>
             </button>
             

--- a/src/components/DMNotification.tsx
+++ b/src/components/DMNotification.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface DMNotificationProps {
+  preview: { conversationId: string; sender: string; content: string } | null;
+  onJump: (id: string) => void;
+}
+
+export function DMNotification({ preview, onJump }: DMNotificationProps) {
+  if (!preview) return null;
+  return (
+    <div
+      className="absolute left-1/2 -translate-x-1/2 mt-2 bg-gray-700 text-white px-4 py-2 rounded-lg shadow-lg cursor-pointer z-50"
+      style={{ top: '4rem' }}
+      onClick={() => onJump(preview.conversationId)}
+    >
+      <p className="text-sm font-semibold">{preview.sender}</p>
+      <p className="text-xs truncate max-w-xs">{preview.content}</p>
+    </div>
+  );
+}

--- a/src/hooks/useDMNotifications.ts
+++ b/src/hooks/useDMNotifications.ts
@@ -1,0 +1,103 @@
+import { useState, useEffect, useRef } from 'react';
+import { supabase } from '../lib/supabase';
+
+interface DMMessage {
+  id: string;
+  sender_id: string;
+  content: string;
+  created_at: string;
+}
+
+interface DMConversation {
+  id: string;
+  user1_id: string;
+  user2_id: string;
+  user1_username: string;
+  user2_username: string;
+  messages: DMMessage[];
+  updated_at: string;
+}
+
+interface DMPreview {
+  conversationId: string;
+  sender: string;
+  content: string;
+}
+
+export function useDMNotifications(userId: string | null) {
+  const [unreadIds, setUnreadIds] = useState<Set<string>>(new Set());
+  const [preview, setPreview] = useState<DMPreview | null>(null);
+  const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const storageKey = `dm_last_read_${userId}`;
+    const getLastRead = (): Record<string, string> => {
+      try {
+        return JSON.parse(localStorage.getItem(storageKey) || '{}');
+      } catch {
+        return {};
+      }
+    };
+
+    const lastRead = getLastRead();
+
+    const handlePayload = (payload: any) => {
+      const conversation = payload.new as DMConversation;
+      const lastMessage = conversation.messages[conversation.messages.length - 1];
+      if (!lastMessage || lastMessage.sender_id === userId) return;
+
+      const readAt = lastRead[conversation.id];
+      if (!readAt || new Date(conversation.updated_at) > new Date(readAt)) {
+        setUnreadIds((prev) => new Set(prev).add(conversation.id));
+        setPreview({
+          conversationId: conversation.id,
+          sender:
+            conversation.user1_id === userId
+              ? conversation.user2_username
+              : conversation.user1_username,
+          content: lastMessage.content,
+        });
+        setTimeout(() => setPreview(null), 2000);
+      }
+    };
+
+    const channel = supabase
+      .channel('dm_notifications')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'dms' }, handlePayload)
+      .subscribe();
+
+    channelRef.current = channel;
+
+    return () => {
+      channel.unsubscribe();
+      channelRef.current = null;
+    };
+  }, [userId]);
+
+  const markAsRead = (conversationId: string, timestamp: string) => {
+    if (!userId) return;
+    setUnreadIds((prev) => {
+      const next = new Set(prev);
+      next.delete(conversationId);
+      return next;
+    });
+    const storageKey = `dm_last_read_${userId}`;
+    let data: Record<string, string> = {};
+    try {
+      data = JSON.parse(localStorage.getItem(storageKey) || '{}');
+    } catch {
+      data = {};
+    }
+    data[conversationId] = timestamp;
+    localStorage.setItem(storageKey, JSON.stringify(data));
+  };
+
+  return {
+    unreadConversations: Array.from(unreadIds),
+    hasUnread: unreadIds.size > 0,
+    preview,
+    markAsRead,
+  };
+}


### PR DESCRIPTION
## Summary
- add hook to manage DM notifications and unread logic
- add DMNotification component for popup preview
- show unread dots in header and DM contacts
- expose unread controls in DMsPage
- integrate notifications in App

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68559cba588c83279a09c10b926b5202