### PR TITLE
Refresh session after inactivity

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -43,6 +43,31 @@ export function useAuth() {
     return () => subscription.unsubscribe();
   }, [hasCheckedSession]);
 
+  useEffect(() => {
+    const refreshSession = async () => {
+      const {
+        data: { session }
+      } = await supabase.auth.getSession();
+      if (session?.user) {
+        await fetchUserProfile(session.user);
+      }
+    };
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        refreshSession();
+      }
+    };
+
+    window.addEventListener('focus', refreshSession);
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      window.removeEventListener('focus', refreshSession);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, []);
+
   const fetchUserProfile = async (authUser: User) => {
     try {
       const { data: profile } = await supabase


### PR DESCRIPTION
## Summary
- refresh auth session on page focus/visibility to avoid expired token

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685855fd00a88327893c78ae09e59564