### PR TITLE
Show timestamp only for last consecutive message

### DIFF
--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -107,8 +107,12 @@ export function ChatArea({
         const items: JSX.Element[] = [];
         let lastDateLabel: string | null = null;
 
-        messages.forEach((message) => {
+        messages.forEach((message, index) => {
           const dateLabel = formatDateGroup(message.created_at);
+          const nextMessage = messages[index + 1];
+          const nextDateLabel = nextMessage
+            ? formatDateGroup(nextMessage.created_at)
+            : null;
 
           if (dateLabel !== lastDateLabel) {
             items.push(
@@ -126,6 +130,11 @@ export function ChatArea({
               isOwnMessage={message.user_id === currentUserId}
               currentUserId={currentUserId}
               onUserClick={onUserClick}
+              showTimestamp={
+                !nextMessage ||
+                nextMessage.user_id !== message.user_id ||
+                dateLabel !== nextDateLabel
+              }
             />
           );
         });

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -8,9 +8,16 @@ interface MessageBubbleProps {
   isOwnMessage: boolean;
   onUserClick?: (userId: string) => void;
   currentUserId?: string;
+  showTimestamp?: boolean;
 }
 
-export function MessageBubble({ message, isOwnMessage, onUserClick, currentUserId }: MessageBubbleProps) {
+export function MessageBubble({
+  message,
+  isOwnMessage,
+  onUserClick,
+  currentUserId,
+  showTimestamp = true,
+}: MessageBubbleProps) {
   const [showPicker, setShowPicker] = useState(false);
   const [isReacting, setIsReacting] = useState(false);
 
@@ -164,12 +171,16 @@ export function MessageBubble({ message, isOwnMessage, onUserClick, currentUserI
           )}
         </div>
         
-        <div className={`flex items-center gap-1 sm:gap-2 mt-1 text-xs text-gray-400 ${
-          isOwnMessage ? 'flex-row-reverse' : ''
-        }`}>
+        <div
+          className={`flex items-center gap-1 sm:gap-2 mt-1 text-xs text-gray-400 ${
+            isOwnMessage ? 'flex-row-reverse' : ''
+          }`}
+        >
           <span className="font-medium text-xs">{message.user_name}</span>
-          <span>•</span>
-          <span className="text-xs">{formatTime(message.created_at)}</span>
+          {showTimestamp && <span>•</span>}
+          {showTimestamp && (
+            <span className="text-xs">{formatTime(message.created_at)}</span>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- add optional `showTimestamp` prop to `MessageBubble`
- calculate if timestamp should display when rendering messages
- render bullet and timestamp conditionally

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68585795805c83278da4e8870984b3c3