### PR TITLE
Fix user name appearing on each message

### DIFF
--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -176,10 +176,12 @@ export function MessageBubble({
             isOwnMessage ? 'flex-row-reverse' : ''
           }`}
         >
-          <span className="font-medium text-xs">{message.user_name}</span>
-          {showTimestamp && <span>•</span>}
           {showTimestamp && (
-            <span className="text-xs">{formatTime(message.created_at)}</span>
+            <>
+              <span className="font-medium text-xs">{message.user_name}</span>
+              <span>•</span>
+              <span className="text-xs">{formatTime(message.created_at)}</span>
+            </>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- show user name only on the last message in a consecutive block from the same user

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68585b3c82608327b24d3a15cfb7269d