### PR TITLE
Update README with Supabase env vars and migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
 # Chat2.0
 
 [Edit in StackBlitz next generation editor ⚡️](https://stackblitz.com/~/github.com/Tayler01/Chat2.0)
+
+## Environment variables
+
+Create a `.env` file in the project root and set the Supabase credentials used by `src/lib/supabase.ts`:
+
+```bash
+VITE_SUPABASE_URL=<your Supabase project URL>
+VITE_SUPABASE_ANON_KEY=<your Supabase anon key>
+```
+
+## Database migrations
+
+This repository stores migrations under `supabase/migrations/`. Apply them to your local Supabase instance with the Supabase CLI:
+
+```bash
+supabase db push       # apply new migrations
+# or
+supabase db reset      # recreate the database with all migrations
+```
+
+If the migrations are not applied, RPC functions such as `upsert_message_read` will respond with a `404` error when called.


### PR DESCRIPTION
## Summary
- expand README with details on required environment variables for Supabase
- document running `supabase db push` or `supabase db reset`
- warn that missing migrations lead to RPC 404 errors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68585e04b3ec832785fb152eb800fc63