### PR TITLE
Add seen user list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,16 +38,20 @@ function App() {
     hasMore,
     markLastRead,
     getSeenCount,
+    getSeenUsers,
   } = useMessages(user?.id ?? null);
 
   const [seenCount, setSeenCount] = useState(0);
+  const [seenUsers, setSeenUsers] = useState<{ username: string; avatar_url: string | null }[]>([]);
 
   const updateSeen = useCallback(async () => {
     if (messages.length === 0) return;
     await markLastRead();
     const count = await getSeenCount(messages[messages.length - 1].id);
+    const users = await getSeenUsers(messages[messages.length - 1].id);
     setSeenCount(Math.max(0, count - 1));
-  }, [messages, markLastRead, getSeenCount]);
+    setSeenUsers(users.filter(u => u.username !== user?.username));
+  }, [messages, markLastRead, getSeenCount, getSeenUsers, user?.username]);
 
   useEffect(() => {
     updateSeen();
@@ -168,6 +172,7 @@ function App() {
         onUserClick={handleUserClick}
         onSeen={updateSeen}
         seenBy={seenCount}
+        seenUsers={seenUsers}
       />
 
       <MessageInput 

--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -17,6 +17,7 @@ interface ChatAreaProps {
   onUserClick?: (userId: string) => void;
   onSeen?: () => void;
   seenBy?: number;
+  seenUsers?: { username: string; avatar_url: string | null }[];
 }
 
 export function ChatArea({
@@ -30,6 +31,7 @@ export function ChatArea({
   onUserClick,
   onSeen,
   seenBy,
+  seenUsers,
 }: ChatAreaProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -150,9 +152,14 @@ export function ChatArea({
         })()}
         <div ref={messagesEndRef} />
       </div>
-      {typeof seenBy === 'number' && seenBy > 0 && (
+      {seenUsers && seenUsers.length > 0 ? (
+        <div className="px-4 py-1 text-xs text-gray-400 flex flex-wrap gap-1">
+          <span>Seen by</span>
+          <span>{seenUsers.map((u) => u.username).join(', ')}</span>
+        </div>
+      ) : typeof seenBy === 'number' && seenBy > 0 ? (
         <div className="px-4 py-1 text-xs text-gray-400">Seen by {seenBy}</div>
-      )}
+      ) : null}
     </>
   );
 }

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -198,6 +198,26 @@ export function useMessages(userId: string | null) {
     return data?.count ?? 0;
   };
 
+  const getSeenUsers = async (messageId: string) => {
+    const { data, error } = await supabase
+      .from('message_reads')
+      .select('users(username, avatar_url)')
+      .eq('message_id', messageId);
+
+    if (error) {
+      console.error('Error fetching users who read message:', error);
+      return [] as { username: string; avatar_url: string | null }[];
+    }
+
+    return (
+      (data as { users: { username: string; avatar_url: string | null } }[] | null)
+        ?.map((row) => ({
+          username: row.users.username,
+          avatar_url: row.users.avatar_url,
+        })) ?? []
+    );
+  };
+
   return {
     messages,
     loading,
@@ -207,6 +227,7 @@ export function useMessages(userId: string | null) {
     hasMore,
     markLastRead,
     getSeenCount,
+    getSeenUsers,
   };
 }
 


### PR DESCRIPTION
## Summary
- track users who have seen a message
- display their names in ChatArea

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685860315b44832780c27bc4090a8d6a