### PR TITLE
Add message pruning trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ supabase db reset      # recreate the database with all migrations
 ```
 
 If the migrations are not applied, RPC functions such as `upsert_message_read` will respond with a `404` error when called.
+
+## Message retention
+
+The Supabase migrations include a trigger named `prune_old_messages` that runs after each insert into the `messages` table. When more than 100 rows exist, it removes the oldest entries so only the newest 100 remain. Remember to run `supabase db push` to apply this behavior.

--- a/supabase/migrations/20250622120000_coral_stream.sql
+++ b/supabase/migrations/20250622120000_coral_stream.sql
@@ -1,0 +1,45 @@
+/*
+  # Prune old messages after insert
+
+  1. Trigger Function
+    - `prune_old_messages` deletes oldest rows when `messages` exceeds 100 entries
+    - Keeps only the 100 newest messages based on `created_at`
+
+  2. Trigger
+    - Runs after each insert into `messages`
+    - Created only if it does not already exist
+*/
+
+-- Create or replace the pruning function
+CREATE OR REPLACE FUNCTION prune_old_messages()
+RETURNS TRIGGER AS $$
+DECLARE
+  total_count INTEGER;
+BEGIN
+  SELECT count(*) INTO total_count FROM messages;
+
+  IF total_count > 100 THEN
+    DELETE FROM messages
+    WHERE id IN (
+      SELECT id FROM messages
+      ORDER BY created_at ASC
+      OFFSET 100
+    );
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Ensure the trigger exists once
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'prune_old_messages_trigger'
+  ) THEN
+    CREATE TRIGGER prune_old_messages_trigger
+      AFTER INSERT ON messages
+      FOR EACH STATEMENT
+      EXECUTE FUNCTION prune_old_messages();
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- create a `prune_old_messages` trigger function and trigger
- explain message retention in README

## Testing
- `npm run lint` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68586bc0670c832781e3b545beb484ae