### PR TITLE
Fix RPC catch usage in markAsRead

### DIFF
--- a/src/hooks/useDMNotifications.ts
+++ b/src/hooks/useDMNotifications.ts
@@ -112,7 +112,7 @@ export function useDMNotifications(userId: string | null) {
     };
   }, [userId]);
 
-  const markAsRead = (
+  const markAsRead = async (
     conversationId: string,
     timestamp: string,
     lastMessageId: string | null
@@ -134,11 +134,15 @@ export function useDMNotifications(userId: string | null) {
     localStorage.setItem(storageKey, JSON.stringify(data));
 
     if (lastMessageId) {
-      supabase.rpc('update_dm_read', {
-        p_conversation_id: conversationId,
-        p_user_id: userId,
-        p_message_id: lastMessageId,
-      }).catch((err) => console.error('Error updating DM read:', err));
+      try {
+        await supabase.rpc('update_dm_read', {
+          p_conversation_id: conversationId,
+          p_user_id: userId,
+          p_message_id: lastMessageId,
+        });
+      } catch (err) {
+        console.error('Error updating DM read:', err);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- convert `markAsRead` to async and await RPC call
- handle RPC errors with try/catch

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68586cf0d9e08327988f9308a9e7dc08