### PR TITLE
Add GRANT for updated DM read function

### DIFF
--- a/supabase/migrations/20250622210300_quiet_grant.sql
+++ b/supabase/migrations/20250622210300_quiet_grant.sql
@@ -1,0 +1,5 @@
+/*
+  # Grant execute permission for update_dm_read
+*/
+
+GRANT EXECUTE ON FUNCTION update_dm_read(uuid, uuid, uuid) TO authenticated;


### PR DESCRIPTION
## Summary
- add migration to grant execute permissions for `update_dm_read`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685871350e548327a9bcbacefee14667