### PR TITLE
Remove old DM reaction function

### DIFF
--- a/supabase/migrations/20250622211220_clean_dm_reaction.sql
+++ b/supabase/migrations/20250622211220_clean_dm_reaction.sql
@@ -1,0 +1,12 @@
+/*
+  # Remove outdated DM reaction function
+
+  Drop the old toggle_dm_reaction function that used a UUID for user_id.
+  Re-grant execute permission on the remaining version that accepts text
+  parameters so authenticated users can continue to toggle reactions.
+*/
+
+DROP FUNCTION IF EXISTS public.toggle_dm_reaction(uuid, text, uuid, text);
+
+-- Re-grant execute privileges on the current function
+GRANT EXECUTE ON FUNCTION toggle_dm_reaction(uuid, text, text, text) TO authenticated;


### PR DESCRIPTION
## Summary
- add migration to drop the outdated `toggle_dm_reaction(uuid, text, uuid, text)`
- re-grant execute permission on the current `toggle_dm_reaction` function

## Testing
- `npm install`
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685871324fec8327b039bcc6c09ec2f6