### PR TITLE
Fix effect dependencies across components

### DIFF
--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -53,7 +53,7 @@ export function ChatArea({
     }
 
     onSeen?.();
-  }, [messages]);
+  }, [messages, onSeen]);
 
   const handleScroll = useCallback(() => {
   const container = containerRef.current;

--- a/src/components/ProfilePreviewModal.tsx
+++ b/src/components/ProfilePreviewModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { X, Mail, Calendar } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 
@@ -23,11 +23,7 @@ export function ProfilePreviewModal({ userId, onClose }: ProfilePreviewModalProp
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetchUserProfile();
-  }, [userId]);
-
-  const fetchUserProfile = async () => {
+  const fetchUserProfile = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -55,7 +51,11 @@ export function ProfilePreviewModal({ userId, onClose }: ProfilePreviewModalProp
     } finally {
       setLoading(false);
     }
-  };
+  }, [userId]);
+
+  useEffect(() => {
+    fetchUserProfile();
+  }, [userId, fetchUserProfile]);
 
   const formatJoinDate = (dateString: string) => {
     if (!dateString) return 'Unknown';

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { X, User, Mail, Palette, Save, Upload, ArrowLeft } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { ChatHeader } from './ChatHeader';
@@ -55,11 +55,7 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
   const [uploadingAvatar, setUploadingAvatar] = useState(false);
   const [uploadingBanner, setUploadingBanner] = useState(false);
 
-  useEffect(() => {
-    fetchUserProfile();
-  }, []);
-
-  const fetchUserProfile = async () => {
+  const fetchUserProfile = useCallback(async () => {
     setLoading(true);
     try {
       const { data, error } = await supabase
@@ -87,7 +83,11 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
     } finally {
       setLoading(false);
     }
-  };
+  }, [user.id, user.username, user.avatar_color]);
+
+  useEffect(() => {
+    fetchUserProfile();
+  }, [fetchUserProfile]);
 
   const handleSave = async () => {
     if (!editData.username.trim()) {

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { supabase } from '../lib/supabase';
 import { Message } from '../types/message';
 
@@ -14,7 +14,7 @@ export function useMessages(userId: string | null) {
   const oldestTimestampRef = useRef<string | null>(null);
   const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
 
-  const subscribeToMessages = () => {
+  const subscribeToMessages = useCallback(() => {
     if (!userId) return;
 
     channelRef.current?.unsubscribe();
@@ -52,7 +52,7 @@ export function useMessages(userId: string | null) {
       .subscribe();
 
     channelRef.current = channel;
-  };
+  }, [userId]);
 
   useEffect(() => {
     if (!userId) return;
@@ -63,7 +63,7 @@ export function useMessages(userId: string | null) {
     return () => {
       channelRef.current?.unsubscribe();
     };
-  }, [userId]);
+  }, [userId, fetchLatestMessages, subscribeToMessages]);
 
   useEffect(() => {
     if (!userId) return;
@@ -87,9 +87,9 @@ export function useMessages(userId: string | null) {
       document.removeEventListener('visibilitychange', handleVisibility);
       window.removeEventListener('focus', handleFocus);
     };
-  }, [userId]);
+  }, [userId, fetchLatestMessages, subscribeToMessages]);
 
-  const fetchLatestMessages = async () => {
+  const fetchLatestMessages = useCallback(async () => {
     try {
       setLoading(true);
 
@@ -114,7 +114,7 @@ export function useMessages(userId: string | null) {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   const fetchOlderMessages = async () => {
     if (loadingOlder || !oldestTimestampRef.current || !hasMore) return;


### PR DESCRIPTION
## Summary
- include `onSeen` in chat area scroll effect dependency list
- memoize profile preview fetcher
- memoize user profile fetcher
- memoize message subscriptions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685875958e348327887810cca8cd1067