### PR TITLE
Fix supabase.rpc usage

### DIFF
--- a/src/hooks/useDMNotifications.ts
+++ b/src/hooks/useDMNotifications.ts
@@ -134,11 +134,17 @@ export function useDMNotifications(userId: string | null) {
     localStorage.setItem(storageKey, JSON.stringify(data));
 
     if (lastMessageId) {
-      supabase.rpc('update_dm_read', {
-        p_conversation_id: conversationId,
-        p_user_id: userId,
-        p_message_id: lastMessageId,
-      }).catch((err) => console.error('Error updating DM read:', err));
+      supabase
+        .rpc('update_dm_read', {
+          p_conversation_id: conversationId,
+          p_user_id: userId,
+          p_message_id: lastMessageId,
+        })
+        .then(({ error }) => {
+          if (error) {
+            console.error('Error updating DM read:', error);
+          }
+        });
     }
   };
 


### PR DESCRIPTION
## Summary
- handle RPC errors with `.then()` instead of `.catch`

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68587b405c20832786237e81d10d68ae