### PR TITLE
Add Supabase connectivity checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ VITE_SUPABASE_URL=<your Supabase project URL>
 VITE_SUPABASE_ANON_KEY=<your Supabase anon key>
 ```
 
+After setting the variables you can verify connectivity with:
+
+```bash
+npm run check:supabase
+```
+
 ## Database migrations
 
 This repository stores migrations under `supabase/migrations/`. Apply them to your local Supabase instance with the Supabase CLI:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "check:supabase": "node scripts/checkSupabase.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",

--- a/scripts/checkSupabase.mjs
+++ b/scripts/checkSupabase.mjs
@@ -1,0 +1,27 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.VITE_SUPABASE_URL;
+const anon = process.env.VITE_SUPABASE_ANON_KEY;
+
+if (!url || !anon) {
+  console.error('Missing environment variables: VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY');
+  process.exit(1);
+}
+
+const supabase = createClient(url, anon);
+
+async function checkConnection() {
+  try {
+    const { error } = await supabase.from('messages').select('id').limit(1);
+    if (error) {
+      console.error('Supabase query failed:', error.message);
+      process.exit(1);
+    }
+    console.log('Supabase connection successful.');
+  } catch (err) {
+    console.error('Failed to connect to Supabase:', err.message);
+    process.exit(1);
+  }
+}
+
+checkConnection();


### PR DESCRIPTION
## Summary
- add `check:supabase` script in `package.json`
- add connectivity instructions in README
- create `scripts/checkSupabase.mjs` to test connection

## Testing
- `npm run lint`
- `npm run build`
- `npm run check:supabase` *(fails: Supabase query failed: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6858812276948327bef05c0178c35a0b