### PR TITLE
Fix DM preview duration

### DIFF
--- a/src/hooks/useDMNotifications.ts
+++ b/src/hooks/useDMNotifications.ts
@@ -94,7 +94,8 @@ export function useDMNotifications(userId: string | null) {
               : conversation.user1_username,
           content: lastMessage.content,
         });
-        setTimeout(() => setPreview(null), 2000);
+        // Keep preview visible for 4 seconds to match the notification display
+        setTimeout(() => setPreview(null), 4000);
       }
     };
 


### PR DESCRIPTION
## Summary
- keep DM previews visible for 4 seconds to match DMNotification timing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685892e4c1bc8327ad9776a4400b1b16