### PR TITLE
Fix scroll fetch trigger for ChatArea

### DIFF
--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -53,7 +53,8 @@ export function ChatArea({
   const container = containerRef.current;
   if (!container || !hasMore || isFetchingRef.current) return;
 
-  if (container.scrollTop === 0) {
+  // Allow a small threshold to improve touch scrolling experience
+  if (container.scrollTop <= 20) {
     const previousHeight = container.scrollHeight;
     isFetchingRef.current = true;
 


### PR DESCRIPTION
## Summary
- adjust `handleScroll` so older messages are fetched when the scroll is near the top

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68589303bb9c83278394f387becf515a