### PR TITLE
Add avatar_url to auth hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ import { useMessages } from './hooks/useMessages';
 import { useAuth } from './hooks/useAuth';
 import { useDMNotifications } from './hooks/useDMNotifications';
 import { LoadingSpinner } from './components/LoadingSpinner';
-import { supabase } from './lib/supabase';
 
 type PageType = 'group-chat' | 'dms' | 'profile';
 
@@ -67,14 +66,13 @@ function App() {
 
   const handleSendMessage = async (content: string) => {
     if (user) {
-      // Get the latest user data including avatar_url
-      const { data: userData } = await supabase
-        .from('users')
-        .select('avatar_url')
-        .eq('id', user.id)
-        .single();
-      
-      await sendMessage(content, user.username, user.id, user.avatar_color, userData?.avatar_url || null);
+      await sendMessage(
+        content,
+        user.username,
+        user.id,
+        user.avatar_color,
+        user.avatar_url || null
+      );
     }
   };
 

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -43,6 +43,7 @@ export function AuthForm({ onAuthSuccess }: AuthFormProps) {
           email: data.user.email,
           username: profile?.username || email.split('@')[0],
           avatar_color: profile?.avatar_color || '#3B82F6',
+          avatar_url: profile?.avatar_url || null,
         });
       } else {
         // Sign up new user
@@ -82,6 +83,7 @@ export function AuthForm({ onAuthSuccess }: AuthFormProps) {
             email: data.user.email,
             username: username.trim(),
             avatar_color: avatarColor,
+            avatar_url: null,
           });
         }
       }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -7,6 +7,7 @@ export interface AuthUser {
   email: string;
   username: string;
   avatar_color: string;
+  avatar_url?: string | null;
 }
 
 export function useAuth() {
@@ -72,7 +73,7 @@ export function useAuth() {
     try {
       const { data: profile } = await supabase
         .from('users')
-        .select('username, avatar_color')
+        .select('username, avatar_color, avatar_url')
         .eq('id', authUser.id)
         .single();
 
@@ -81,6 +82,7 @@ export function useAuth() {
         email: authUser.email || '',
         username: profile?.username || authUser.email?.split('@')[0] || 'User',
         avatar_color: profile?.avatar_color || '#3B82F6',
+        avatar_url: profile?.avatar_url || null,
       });
     } catch (error) {
       console.error('Error fetching user profile:', error);
@@ -89,6 +91,7 @@ export function useAuth() {
         email: authUser.email || '',
         username: authUser.email?.split('@')[0] || 'User',
         avatar_color: '#3B82F6',
+        avatar_url: null,
       });
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary
- cache `avatar_url` in `useAuth`
- remove avatar query in `handleSendMessage`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6858a16e9fa08327b60d0f0965f53f58