### PR TITLE
Implement global toast notifications

### DIFF
--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { Search, MessageSquare, Send, X, Clock, Users, ArrowLeft } from 'lucide-react';
 import { Smile } from 'lucide-react';
 import { supabase } from '../lib/supabase';
+import { useToast } from './Toast';
 
 interface User {
   id: string;
@@ -73,6 +74,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
   const [messageLimit, setMessageLimit] = useState(DM_PAGE_SIZE);
   const [showReactionPicker, setShowReactionPicker] = useState<string | null>(null);
   const [isReacting, setIsReacting] = useState(false);
+  const { show } = useToast();
 
   const getConversationWithUser = useCallback(
     (userId: string) =>
@@ -399,7 +401,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
     } catch (error) {
       console.error('Error toggling DM reaction:', error);
       // Show user-friendly error message
-      alert('Failed to add reaction. Please try again.');
+      show('Failed to add reaction. Please try again.');
     } finally {
       setIsReacting(false);
     }

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Smile } from 'lucide-react';
 import { Message } from '../types/message';
 import { supabase } from '../lib/supabase';
+import { useToast } from './Toast';
 
 interface MessageBubbleProps {
   message: Message;
@@ -20,6 +21,7 @@ export function MessageBubble({
 }: MessageBubbleProps) {
   const [showPicker, setShowPicker] = useState(false);
   const [isReacting, setIsReacting] = useState(false);
+  const { show } = useToast();
 
   const formatTime = (timestamp: string) => {
     return new Date(timestamp).toLocaleTimeString([], {
@@ -45,7 +47,7 @@ export function MessageBubble({
     } catch (error) {
       console.error('Error toggling reaction:', error);
       // Show user-friendly error message
-      alert('Failed to add reaction. Please try again.');
+      show('Failed to add reaction. Please try again.');
     } finally {
       setIsReacting(false);
     }

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,49 @@
+import React, { createContext, useCallback, useContext, useState, ReactNode } from 'react';
+
+interface ToastContextValue {
+  show: (message: string) => void;
+}
+
+interface Toast {
+  id: number;
+  message: string;
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+export const ToastProvider = ({ children }: { children: ReactNode }) => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const remove = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const show = useCallback((message: string) => {
+    const id = Date.now() + Math.random();
+    setToasts((prev) => [...prev, { id, message }]);
+    setTimeout(() => remove(id), 3000);
+  }, [remove]);
+
+  return (
+    <ToastContext.Provider value={{ show }}>
+      {children}
+      <div className="fixed bottom-4 left-1/2 -translate-x-1/2 space-y-2 z-50">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className="bg-gray-800 text-white px-3 py-2 rounded shadow"
+          >
+            {toast.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used within ToastProvider');
+  return ctx;
+};
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+import { ToastProvider } from './components/Toast';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ToastProvider>
+      <App />
+    </ToastProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- create Toast component with provider and hook
- show toast container at app root
- replace browser alerts with toast messages

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6858a173f4a48327ab64291e8cb2d1ab