### PR TITLE
Fix DM chat area height on mobile

### DIFF
--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -662,7 +662,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
         <div className={`${
           selectedConversation ? 'flex' : 'hidden md:flex'
         } flex-1 bg-gray-800 rounded-xl border border-gray-600/50 shadow-xl flex-col overflow-hidden min-h-0 ${
-          selectedConversation ? 'absolute md:relative inset-0 md:inset-auto z-10 md:z-auto' : ''
+          selectedConversation ? 'absolute md:relative inset-0 md:inset-auto z-10 md:z-auto h-full w-full' : ''
         }`}>
           {selectedConversation ? (
             <>


### PR DESCRIPTION
## Summary
- ensure DM chat window fills available space on mobile

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858cc6835488327aa6260564619be51