### PR TITLE
Fix viewport sizing with dynamic units

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -53,9 +53,16 @@
   padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
 }
 
+.h-screen {
+  height: 100dvh;
+  height: 100svh;
+}
+
 @supports (-webkit-touch-callout: none) {
   .h-screen {
     height: -webkit-fill-available;
+    height: 100dvh;
+    height: 100svh;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep iOS fallback for `.h-screen`
- use `100dvh`/`100svh` for `.h-screen`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6858d116bf508327bc5a2bfcea9674be