### PR TITLE
Add presence tracking for active users

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Create a `.env` file in the project root and set the Supabase credentials used b
 ```bash
 VITE_SUPABASE_URL=<your Supabase project URL>
 VITE_SUPABASE_ANON_KEY=<your Supabase anon key>
+VITE_PRESENCE_INTERVAL_MS=30000 # optional presence ping interval in ms
 ```
 
 ## Database migrations
@@ -21,4 +22,4 @@ supabase db push       # apply new migrations
 supabase db reset      # recreate the database with all migrations
 ```
 
-The latest migrations remove the unused `subscriptions` table that previously stored push-notification data.
+The latest migrations add a `last_active` column and `update_user_last_active` function for presence tracking. Run `supabase db push` after pulling updates.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { useMessages } from './hooks/useMessages';
 import { useAuth } from './hooks/useAuth';
 import { useDMNotifications } from './hooks/useDMNotifications';
 import { LoadingSpinner } from './components/LoadingSpinner';
+import { usePresence } from './hooks/usePresence';
 
 type PageType = 'group-chat' | 'dms' | 'profile';
 
@@ -36,6 +37,8 @@ function App() {
     fetchOlderMessages,
     hasMore,
   } = useMessages(user?.id ?? null);
+
+  const activeUserIds = usePresence();
 
   // Show loading spinner while checking auth
   if (authLoading) {
@@ -152,6 +155,7 @@ function App() {
         fetchOlderMessages={fetchOlderMessages}
         hasMore={hasMore}
         onUserClick={handleUserClick}
+        activeUserIds={activeUserIds}
       />
 
       <MessageInput 

--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -15,6 +15,7 @@ interface ChatAreaProps {
   fetchOlderMessages: () => void;
   hasMore: boolean;
   onUserClick?: (userId: string) => void;
+  activeUserIds: string[];
 }
 
 export function ChatArea({
@@ -26,7 +27,8 @@ export function ChatArea({
   fetchOlderMessages,
   hasMore,
   onUserClick,
-  
+  activeUserIds,
+
 }: ChatAreaProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -134,6 +136,7 @@ export function ChatArea({
               isOwnMessage={message.user_id === currentUserId}
               currentUserId={currentUserId}
               onUserClick={onUserClick}
+              activeUserIds={activeUserIds}
               showTimestamp={
                 !nextMessage ||
                 nextMessage.user_id !== message.user_id ||

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -10,6 +10,7 @@ interface MessageBubbleProps {
   onUserClick?: (userId: string) => void;
   currentUserId?: string;
   showTimestamp?: boolean;
+  activeUserIds: string[];
 }
 
 export function MessageBubble({
@@ -18,10 +19,12 @@ export function MessageBubble({
   onUserClick,
   currentUserId,
   showTimestamp = true,
+  activeUserIds,
 }: MessageBubbleProps) {
   const [showPicker, setShowPicker] = useState(false);
   const [isReacting, setIsReacting] = useState(false);
   const { show } = useToast();
+  const isActive = activeUserIds.includes(message.user_id);
 
   const formatTime = (timestamp: string) => {
     return new Date(timestamp).toLocaleTimeString([], {
@@ -99,6 +102,9 @@ export function MessageBubble({
           <span className="avatar-fallback absolute inset-0 flex items-center justify-center text-white text-xs sm:text-sm font-medium" style={{ display: 'none' }}>
             {message.user_name.charAt(0).toUpperCase()}
           </span>
+        )}
+        {isActive && (
+          <span className="absolute -bottom-0.5 -right-0.5 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900" />
         )}
       </button>
       

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -168,6 +168,8 @@ export function useMessages(userId: string | null) {
       });
 
       if (error) throw error;
+
+      await supabase.rpc('update_user_last_active');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to send message');
     }

--- a/src/hooks/usePresence.ts
+++ b/src/hooks/usePresence.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState } from 'react';
+import { supabase } from '../lib/supabase';
+
+const INTERVAL = Number(import.meta.env.VITE_PRESENCE_INTERVAL_MS) || 30000;
+
+export function usePresence() {
+  const [activeUserIds, setActiveUserIds] = useState<string[]>([]);
+  const intervalRef = useRef<number | null>(null);
+
+  const updatePresence = async () => {
+    try {
+      await supabase.rpc('update_user_last_active');
+    } catch (err) {
+      console.error('Failed to update last_active', err);
+    }
+  };
+
+  useEffect(() => {
+    updatePresence();
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        updatePresence();
+      }
+    };
+
+    window.addEventListener('focus', updatePresence);
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    intervalRef.current = window.setInterval(updatePresence, INTERVAL);
+
+    return () => {
+      window.removeEventListener('focus', updatePresence);
+      document.removeEventListener('visibilitychange', handleVisibility);
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const FIVE_MIN = 5 * 60 * 1000;
+
+    const fetchActive = async () => {
+      const since = new Date(Date.now() - FIVE_MIN).toISOString();
+      const { data } = await supabase
+        .from('users')
+        .select('id')
+        .gte('last_active', since);
+      setActiveUserIds((data || []).map((u) => u.id));
+    };
+
+    fetchActive();
+
+    const channel = supabase
+      .channel('presence-users')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'users' },
+        (payload) => {
+          const user = payload.new as { id: string; last_active: string };
+          const active =
+            new Date(user.last_active).getTime() > Date.now() - FIVE_MIN;
+          setActiveUserIds((prev) => {
+            const set = new Set(prev);
+            if (active) {
+              set.add(user.id);
+            } else {
+              set.delete(user.id);
+            }
+            return Array.from(set);
+          });
+        }
+      )
+      .subscribe();
+
+    return () => {
+      channel.unsubscribe();
+    };
+  }, []);
+
+  return activeUserIds;
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -29,6 +29,7 @@ export interface Database {
           bio: string | null;
           created_at: string | null;
           updated_at: string | null;
+          last_active: string | null;
         };
         Insert: {
           id: string;
@@ -40,6 +41,7 @@ export interface Database {
           bio?: string | null;
           created_at?: string | null;
           updated_at?: string | null;
+          last_active?: string | null;
         };
         Update: {
           id?: string;
@@ -51,6 +53,7 @@ export interface Database {
           bio?: string | null;
           created_at?: string | null;
           updated_at?: string | null;
+          last_active?: string | null;
         };
       };
       messages: {

--- a/supabase/migrations/20250621000000_crimson_presence.sql
+++ b/supabase/migrations/20250621000000_crimson_presence.sql
@@ -1,0 +1,35 @@
+/*
+  # Track user presence
+
+  1. Schema
+    - Add `last_active` timestamptz column to `users` with default `now()`
+    - Index on `last_active` for quick lookups
+
+  2. Function
+    - `update_user_last_active` sets the column for the current auth user
+    - Grant execute permission to `authenticated`
+*/
+
+-- Add last_active column
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'users' AND column_name = 'last_active'
+  ) THEN
+    ALTER TABLE users ADD COLUMN last_active timestamptz NOT NULL DEFAULT now();
+  END IF;
+END $$;
+
+-- Index for faster queries
+CREATE INDEX IF NOT EXISTS users_last_active_idx ON users(last_active DESC);
+
+-- RPC to update current user's last_active
+CREATE OR REPLACE FUNCTION update_user_last_active()
+RETURNS void AS $$
+BEGIN
+  UPDATE users SET last_active = now() WHERE id = auth.uid();
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION update_user_last_active() TO authenticated;


### PR DESCRIPTION
## Summary
- add `last_active` column and RPC to migrations
- track presence with new `usePresence` hook
- show active state indicator on message avatars
- refresh last_active when sending messages
- expose presence configuration env var in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858d228d9948327a878bd2e650e7d15