### PR TITLE
Fix DM contact loading after idle

### DIFF
--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -286,6 +286,29 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
     cleanupConnections
   ]);
 
+  // Refresh users and conversations when the page regains focus or becomes
+  // visible. This helps recover if the tab was idle for a while.
+  useEffect(() => {
+    const handleRefresh = () => {
+      fetchUsers();
+      fetchConversations();
+    };
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        handleRefresh();
+      }
+    };
+
+    window.addEventListener('focus', handleRefresh);
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      window.removeEventListener('focus', handleRefresh);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [fetchUsers, fetchConversations]);
+
   useEffect(() => {
     if (!selectedConversation) return;
     setMessageLimit((limit) =>


### PR DESCRIPTION
## Summary
- refresh user and conversation data when window regains focus or becomes visible

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6858d755b45483278d5aecb026cc94a0