### PR TITLE
Adjust online indicator position

### DIFF
--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -592,7 +592,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                                   </div>
                                 )}
                                 {activeUserIds.includes(otherUserData.id) && (
-                                  <span className="absolute bottom-0 right-0 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900" />
+                                  <span className="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900 z-10" />
                                 )}
                               </div>
                               <div className="flex-1 min-w-0">
@@ -658,7 +658,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                                 </div>
                               )}
                               {activeUserIds.includes(user.id) && (
-                                <span className="absolute bottom-0 right-0 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900" />
+                                <span className="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900 z-10" />
                               )}
                             </div>
                             <div className="flex-1 min-w-0">
@@ -729,7 +729,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                             </div>
                           )}
                           {activeUserIds.includes(otherUserData.id) && (
-                            <span className="absolute bottom-0 right-0 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900" />
+                            <span className="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900 z-10" />
                           )}
                         </div>
                         <div>
@@ -813,7 +813,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                           );
                         })()}
                         {activeUserIds.includes(message.sender_id) && (
-                          <span className="absolute bottom-0 right-0 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900" />
+                          <span className="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900 z-10" />
                         )}
                       </button>
                       

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -104,7 +104,7 @@ export function MessageBubble({
           </span>
         )}
         {isActive && (
-          <span className="absolute bottom-0 right-0 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900" />
+          <span className="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900 z-10" />
         )}
       </button>
       


### PR DESCRIPTION
## Summary
- show status dot overlapping avatars so it's clear the user is online

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6858d8b79f448327a0479b29600196ca