### PR TITLE
Fix session refresh when returning to web app

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -51,6 +51,9 @@ export function useAuth() {
       } = await supabase.auth.getSession();
       if (session?.user) {
         await fetchUserProfile(session.user);
+      } else {
+        setUser(null);
+        setLoading(false);
       }
     };
 


### PR DESCRIPTION
## Summary
- clear user session if `supabase.auth.getSession()` returns null

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858d9f147088327a2cdb7a076dcc812