### PR TITLE
Show presence only on most recent messages

### DIFF
--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -35,6 +35,14 @@ export function ChatArea({
   const hasAutoScrolled = useRef(false);
   const isFetchingRef = useRef(false);
 
+  const latestMessageByUser = React.useMemo(() => {
+    const map = new Map<string, string>();
+    messages.forEach((m) => {
+      map.set(m.user_id, m.id);
+    });
+    return map;
+  }, [messages]);
+
   useEffect(() => {
     const container = containerRef.current;
     if (!container || messages.length === 0) return;
@@ -137,6 +145,7 @@ export function ChatArea({
               currentUserId={currentUserId}
               onUserClick={onUserClick}
               activeUserIds={activeUserIds}
+              showActiveDot={latestMessageByUser.get(message.user_id) === message.id}
               showTimestamp={
                 !nextMessage ||
                 nextMessage.user_id !== message.user_id ||

--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -119,6 +119,16 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
     return msgs.slice(start);
   }, [selectedConversation, messageLimit]);
 
+  const latestMessageByUser = useMemo(() => {
+    const map = new Map<string, string>();
+    if (selectedConversation) {
+      (selectedConversation.messages || []).forEach((m) => {
+        map.set(m.sender_id, m.id);
+      });
+    }
+    return map;
+  }, [selectedConversation?.messages]);
+
   const cleanupConnections = useCallback(() => {
     if (channelRef.current) {
       channelRef.current.unsubscribe();
@@ -820,9 +830,10 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                               );
                             })()}
                           </div>
-                          {activeUserIds.includes(message.sender_id) && (
-                            <span className="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900 z-10" />
-                          )}
+                          {activeUserIds.includes(message.sender_id) &&
+                            latestMessageByUser.get(message.sender_id) === message.id && (
+                              <span className="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900 z-10" />
+                            )}
                         </button>
                       
                       <div className={`flex flex-col max-w-xs sm:max-w-md relative ${

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -11,6 +11,7 @@ interface MessageBubbleProps {
   currentUserId?: string;
   showTimestamp?: boolean;
   activeUserIds: string[];
+  showActiveDot?: boolean;
 }
 
 export function MessageBubble({
@@ -20,11 +21,12 @@ export function MessageBubble({
   currentUserId,
   showTimestamp = true,
   activeUserIds,
+  showActiveDot = true,
 }: MessageBubbleProps) {
   const [showPicker, setShowPicker] = useState(false);
   const [isReacting, setIsReacting] = useState(false);
   const { show } = useToast();
-  const isActive = activeUserIds.includes(message.user_id);
+  const isActive = showActiveDot && activeUserIds.includes(message.user_id);
 
   const formatTime = (timestamp: string) => {
     return new Date(timestamp).toLocaleTimeString([], {


### PR DESCRIPTION
## Summary
- refine MessageBubble presence logic with new `showActiveDot` prop
- show presence indicator only next to user's latest message in ChatArea
- mirror latest message logic in DMsPage conversation view

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6858dc1f807c8327a497c3d8d0038ffa