### PR TITLE
Implement active user avatars in chat header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { useAuth } from './hooks/useAuth';
 import { useDMNotifications } from './hooks/useDMNotifications';
 import { LoadingSpinner } from './components/LoadingSpinner';
 import { usePresence } from './hooks/usePresence';
+import { useActiveUserProfiles } from './hooks/useActiveUserProfiles';
 
 type PageType = 'group-chat' | 'dms' | 'profile';
 
@@ -39,6 +40,7 @@ function App() {
   } = useMessages(user?.id ?? null);
 
   const activeUserIds = usePresence();
+  const activeUsers = useActiveUserProfiles(activeUserIds);
 
   // Show loading spinner while checking auth
   if (authLoading) {
@@ -98,6 +100,7 @@ function App() {
             currentPage={currentPage}
             onPageChange={setCurrentPage}
             hasUnreadDMs={hasUnread}
+            activeUsers={activeUsers}
           />
         </div>
         <DMNotification
@@ -138,6 +141,7 @@ function App() {
         currentPage={currentPage}
         onPageChange={setCurrentPage}
         hasUnreadDMs={hasUnread}
+        activeUsers={activeUsers}
       />
       <DMNotification
         preview={dmPreview}

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -10,9 +10,10 @@ interface ChatHeaderProps {
   currentPage: PageType;
   onPageChange: (page: PageType) => void;
   hasUnreadDMs?: boolean;
+  activeUsers?: { id: string; username: string; avatar_url: string | null; avatar_color: string; }[];
 }
 
-export function ChatHeader({ userName, onClearUser, onShowProfile, currentPage, onPageChange, hasUnreadDMs }: ChatHeaderProps) {
+export function ChatHeader({ userName, onClearUser, onShowProfile, currentPage, onPageChange, hasUnreadDMs, activeUsers = [] }: ChatHeaderProps) {
   const [showMenu, setShowMenu] = useState(false);
   const [showMobileNav, setShowMobileNav] = useState(false);
 
@@ -126,7 +127,23 @@ export function ChatHeader({ userName, onClearUser, onShowProfile, currentPage, 
           </div>
         </div>
       </div>
-      
+
+      {currentPage === 'group-chat' && activeUsers.length > 0 && (
+        <div className="hidden md:flex absolute inset-0 pointer-events-none items-center justify-center gap-2">
+          {activeUsers.map((u) => (
+            <div key={u.id} className="w-8 h-8 rounded-full overflow-hidden ring-2 ring-gray-700">
+              {u.avatar_url ? (
+                <img src={u.avatar_url} alt={u.username} className="w-full h-full object-cover" />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center text-xs font-medium text-white" style={{ backgroundColor: u.avatar_color }}>
+                  {u.username.charAt(0).toUpperCase()}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
       {/* Mobile Navigation Menu */}
       {showMobileNav && (
         <div className="md:hidden absolute top-full left-0 right-0 bg-gray-800 border-b border-gray-700 shadow-lg z-50">

--- a/src/hooks/useActiveUserProfiles.ts
+++ b/src/hooks/useActiveUserProfiles.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase';
+
+export interface ActiveUserProfile {
+  id: string;
+  username: string;
+  avatar_url: string | null;
+  avatar_color: string;
+}
+
+export function useActiveUserProfiles(activeUserIds: string[]) {
+  const [profiles, setProfiles] = useState<ActiveUserProfile[]>([]);
+
+  useEffect(() => {
+    if (activeUserIds.length === 0) {
+      setProfiles([]);
+      return;
+    }
+
+    const fetchProfiles = async () => {
+      const { data, error } = await supabase
+        .from('users')
+        .select('id, username, avatar_url, avatar_color')
+        .in('id', activeUserIds);
+      if (error) {
+        console.error('Error fetching active user profiles', error);
+        setProfiles([]);
+      } else {
+        setProfiles(data || []);
+      }
+    };
+
+    fetchProfiles();
+  }, [activeUserIds]);
+
+  return profiles;
+}


### PR DESCRIPTION
## Summary
- add `useActiveUserProfiles` hook to fetch active user info
- show active avatars in `ChatHeader` on desktop group chat
- use new hook in `App` and pass data to header

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6858dcb727d0832786a44bc6e46e2372