### PR TITLE
Improve presence updates and real-time avatars

### DIFF
--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -77,6 +77,13 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
   const [showReactionPicker, setShowReactionPicker] = useState<string | null>(null);
   const [isReacting, setIsReacting] = useState(false);
   const { show } = useToast();
+  const updatePresence = async () => {
+    try {
+      await supabase.rpc('update_user_last_active');
+    } catch (err) {
+      console.error('Failed to update presence', err);
+    }
+  };
 
   const getConversationWithUser = useCallback(
     (userId: string) =>
@@ -238,6 +245,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
 
       if (error) throw error;
       setUsers(data || []);
+      await updatePresence();
     } catch (err) {
       console.error('Error fetching users:', err);
     }
@@ -255,6 +263,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
 
       if (error) throw error;
       setConversations((data || []).map(normalizeConversation));
+      await updatePresence();
     } catch (err) {
       console.error('Error fetching conversations:', err);
     } finally {
@@ -302,6 +311,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
     const handleRefresh = () => {
       fetchUsers();
       fetchConversations();
+      updatePresence();
     };
 
     const handleVisibility = () => {
@@ -349,6 +359,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
         selectedConversation.updated_at
       );
     }
+    updatePresence();
   }, [selectedConversation?.messages, messageLimit, selectedConversation, onConversationOpen]);
 
   useEffect(() => {
@@ -400,6 +411,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
         if (exists) return prev;
         return [normalized, ...prev];
       });
+      await updatePresence();
     } catch (err) {
       console.error('Error starting conversation:', err);
     }
@@ -416,6 +428,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
       });
 
       setNewMessage('');
+      await updatePresence();
     } catch (err) {
       console.error('Error sending message:', err);
     }

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -89,6 +89,14 @@ export function useMessages(userId: string | null) {
     };
   }, [userId]);
 
+  const updatePresence = async () => {
+    try {
+      await supabase.rpc('update_user_last_active');
+    } catch (err) {
+      console.error('Failed to update last_active', err);
+    }
+  };
+
   const fetchLatestMessages = async () => {
     try {
       setLoading(true);
@@ -109,6 +117,7 @@ export function useMessages(userId: string | null) {
       }
 
       setHasMore((data || []).length === PAGE_SIZE);
+      await updatePresence();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load messages');
     } finally {
@@ -144,6 +153,7 @@ export function useMessages(userId: string | null) {
       }
 
       setHasMore((data || []).length === PAGE_SIZE);
+      await updatePresence();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load older messages');
     } finally {


### PR DESCRIPTION
## Summary
- update active user profiles in real time
- mark users active when fetching messages or viewing DMs
- ping presence when refreshing DMs

## Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858ded3abe4832792aa6e3f3931c862