### PR TITLE
Reload on focus

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,26 @@ import App from './App.tsx';
 import { ToastProvider } from './components/Toast';
 import './index.css';
 
+// Reload the entire page whenever the tab regains focus after being
+// backgrounded. This helps recover when the app becomes flaky after a
+// long period of inactivity.
+let hasFocusedOnce = document.hasFocus();
+
+const reloadOnFocus = () => {
+  if (hasFocusedOnce) {
+    window.location.reload();
+  } else {
+    hasFocusedOnce = true;
+  }
+};
+
+window.addEventListener('focus', reloadOnFocus);
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    reloadOnFocus();
+  }
+});
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ToastProvider>


### PR DESCRIPTION
## Summary
- force a page reload whenever the tab regains focus

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858df79b0288327ad2f9871094b2abd