### PR TITLE
Fix DM contacts page stuck loading

### DIFF
--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -729,6 +729,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                 <button
                   onClick={() => {
                     setSelectedConversation(null);
+                    setLoading(false);
                   }}
                   className="md:hidden p-2 text-gray-300 hover:text-white hover:bg-gray-700/60 rounded-xl transition-colors mr-3"
                 >
@@ -772,7 +773,10 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                   })()}
                 </div>
                 <button
-                  onClick={() => setSelectedConversation(null)}
+                  onClick={() => {
+                    setSelectedConversation(null);
+                    setLoading(false);
+                  }}
                   className="hidden md:block p-2 text-gray-300 hover:text-white hover:bg-gray-700/60 rounded-xl transition-colors"
                 >
                   <X className="w-5 h-5" />


### PR DESCRIPTION
## Summary
- ensure the contacts list stops loading when closing a direct message

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685937476c0c8327bfb5a236db060b9d