### PR TITLE
Fix group chat stale state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { AuthForm } from './components/AuthForm';
 import { ChatHeader } from './components/ChatHeader';
 import { ChatArea } from './components/ChatArea';
@@ -37,7 +37,15 @@ function App() {
     sendMessage,
     fetchOlderMessages,
     hasMore,
+    refresh,
   } = useMessages(user?.id ?? null);
+
+  // Refresh group chat data whenever returning to the group chat page
+  useEffect(() => {
+    if (currentPage === 'group-chat') {
+      refresh();
+    }
+  }, [currentPage, refresh]);
 
   const activeUserIds = usePresence();
   const activeUsers = useActiveUserProfiles(activeUserIds);

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -54,6 +54,12 @@ export function useMessages(userId: string | null) {
     channelRef.current = channel;
   };
 
+  const refresh = () => {
+    if (!userId) return;
+    subscribeToMessages();
+    fetchLatestMessages();
+  };
+
   useEffect(() => {
     if (!userId) return;
 
@@ -193,6 +199,7 @@ export function useMessages(userId: string | null) {
     sendMessage,
     fetchOlderMessages,
     hasMore,
+    refresh,
   };
 }
 


### PR DESCRIPTION
## Summary
- add a `refresh` helper in `useMessages`
- call `refresh` when switching back to group chat

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685938df7ffc83279d69a90519de0334