### PR TITLE
Revert two earlier changes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { AuthForm } from './components/AuthForm';
 import { ChatHeader } from './components/ChatHeader';
 import { ChatArea } from './components/ChatArea';
@@ -37,15 +37,8 @@ function App() {
     sendMessage,
     fetchOlderMessages,
     hasMore,
-    refresh,
   } = useMessages(user?.id ?? null);
 
-  // Refresh group chat data whenever returning to the group chat page
-  useEffect(() => {
-    if (currentPage === 'group-chat') {
-      refresh();
-    }
-  }, [currentPage, refresh]);
 
   const activeUserIds = usePresence();
   const activeUsers = useActiveUserProfiles(activeUserIds);

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -69,18 +69,16 @@ export function ChatHeader({ userName, onClearUser, onShowProfile, currentPage, 
             </button>
           </div>
           
-          {/* Mobile Navigation Toggle (hidden on profile page) */}
-          {currentPage !== 'profile' && (
-            <button
-              onClick={() => setShowMobileNav(!showMobileNav)}
-              className="relative md:hidden p-2 text-gray-300 hover:text-white hover:bg-gray-700 rounded-lg transition-colors ml-2"
-            >
-              {showMobileNav ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
-              {hasUnreadDMs && !showMobileNav && (
-                <span className="absolute -top-1 -right-1 block w-2 h-2 bg-red-500 rounded-full" />
-              )}
-            </button>
-          )}
+          {/* Mobile Navigation Toggle */}
+          <button
+            onClick={() => setShowMobileNav(!showMobileNav)}
+            className="relative md:hidden p-2 text-gray-300 hover:text-white hover:bg-gray-700 rounded-lg transition-colors ml-2"
+          >
+            {showMobileNav ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
+            {hasUnreadDMs && !showMobileNav && (
+              <span className="absolute -top-1 -right-1 block w-2 h-2 bg-red-500 rounded-full" />
+            )}
+          </button>
         </div>
         
         <div className="flex items-center gap-4">

--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -729,7 +729,6 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                 <button
                   onClick={() => {
                     setSelectedConversation(null);
-                    setLoading(false);
                   }}
                   className="md:hidden p-2 text-gray-300 hover:text-white hover:bg-gray-700/60 rounded-xl transition-colors mr-3"
                 >
@@ -775,7 +774,6 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                 <button
                   onClick={() => {
                     setSelectedConversation(null);
-                    setLoading(false);
                   }}
                   className="hidden md:block p-2 text-gray-300 hover:text-white hover:bg-gray-700/60 rounded-xl transition-colors"
                 >

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { supabase } from '../lib/supabase';
 import { Message } from '../types/message';
 
@@ -14,7 +14,7 @@ export function useMessages(userId: string | null) {
   const oldestTimestampRef = useRef<string | null>(null);
   const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
 
-  const subscribeToMessages = useCallback(() => {
+  const subscribeToMessages = () => {
     if (!userId) return;
 
     channelRef.current?.unsubscribe();
@@ -52,13 +52,8 @@ export function useMessages(userId: string | null) {
       .subscribe();
 
     channelRef.current = channel;
-  }, [userId]);
+  };
 
-  const refresh = useCallback(() => {
-    if (!userId) return;
-    subscribeToMessages();
-    fetchLatestMessages();
-  }, [userId, subscribeToMessages, fetchLatestMessages]);
 
   useEffect(() => {
     if (!userId) return;
@@ -69,7 +64,7 @@ export function useMessages(userId: string | null) {
     return () => {
       channelRef.current?.unsubscribe();
     };
-  }, [userId, fetchLatestMessages, subscribeToMessages]);
+  }, [userId]);
 
   useEffect(() => {
     if (!userId) return;
@@ -93,7 +88,7 @@ export function useMessages(userId: string | null) {
       document.removeEventListener('visibilitychange', handleVisibility);
       window.removeEventListener('focus', handleFocus);
     };
-  }, [userId, subscribeToMessages, fetchLatestMessages]);
+  }, [userId]);
 
   const updatePresence = async () => {
     try {
@@ -103,7 +98,7 @@ export function useMessages(userId: string | null) {
     }
   };
 
-  const fetchLatestMessages = useCallback(async () => {
+  const fetchLatestMessages = async () => {
     try {
       setLoading(true);
 
@@ -129,7 +124,7 @@ export function useMessages(userId: string | null) {
     } finally {
       setLoading(false);
     }
-  }, []);
+  };
 
   const fetchOlderMessages = async () => {
     if (loadingOlder || !oldestTimestampRef.current || !hasMore) return;
@@ -199,7 +194,6 @@ export function useMessages(userId: string | null) {
     sendMessage,
     fetchOlderMessages,
     hasMore,
-    refresh,
   };
 }
 


### PR DESCRIPTION
## Summary
- remove group chat refresh hook and `refresh` export from `useMessages`
- remove `setLoading(false)` in DM close buttons

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68594057969c8327bdb1a443e76a7207