### PR TITLE
Fix message input focus after sending

### DIFF
--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -15,6 +15,8 @@ export function MessageInput({ onSendMessage, disabled }: MessageInputProps) {
     if (message.trim() && !disabled) {
       onSendMessage(message.trim());
       setMessage('');
+      // Keep the textarea focused so the keyboard stays open
+      textareaRef.current?.focus();
     }
   };
 


### PR DESCRIPTION
## Summary
- keep the message input focused after submitting

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685972f37a608327b0290d8dcbcb8362