### PR TITLE
Fix sticky header in group chat

### DIFF
--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -23,7 +23,7 @@ export function ChatHeader({ userName, onClearUser, onShowProfile, currentPage, 
   };
 
   return (
-    <div className="bg-gray-800 border-b border-gray-700 p-4 shadow-lg relative">
+    <div className="bg-gray-800 border-b border-gray-700 p-4 shadow-lg relative sticky top-0 z-50">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 sm:gap-6 sm:ml-8">
           {/* Logo */}


### PR DESCRIPTION
## Summary
- keep the ChatHeader fixed at the top even when the keyboard is open

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859859e4c908327b13a01c5d0ac8e14