### PR TITLE
Shrink mobile header

### DIFF
--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -23,7 +23,7 @@ export function ChatHeader({ userName, onClearUser, onShowProfile, currentPage, 
   };
 
   return (
-    <div className="bg-gray-800 border-b border-gray-700 p-4 shadow-lg relative sticky top-0 z-50">
+    <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 sm:p-4 shadow-lg relative sticky top-0 z-50">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 sm:gap-6 sm:ml-8">
           {/* Logo */}

--- a/src/components/DMNotification.tsx
+++ b/src/components/DMNotification.tsx
@@ -47,17 +47,12 @@ export function DMNotification({ preview, onJump }: DMNotificationProps) {
   if (!shouldRender || !preview) return null;
 
   return (
-    <div 
-      className={`fixed z-50 transition-all duration-300 ease-out ${
-        isVisible 
-          ? 'translate-y-0 opacity-100' 
+    <div
+      className={`fixed z-50 transition-all duration-300 ease-out left-0 right-0 ${
+        isVisible
+          ? 'translate-y-0 opacity-100'
           : '-translate-y-full opacity-0'
-      }`}
-      style={{ 
-        top: '5rem', // Position under header
-        left: '0',
-        right: '0'
-      }}
+      } top-12 md:top-20`}
     >
       {/* Desktop notification - positioned to the right */}
       <div className="hidden md:block">


### PR DESCRIPTION
## Summary
- reduce header padding on small screens
- position DM notifications based on screen size

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685986a437888327a0bdf46e2cb9ad4b