### PR TITLE
Fix mobile header visibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,7 +91,7 @@ function App() {
   // Show DMs page
   if (currentPage === 'dms') {
     return (
-      <div className="flex flex-col h-screen bg-gray-900">
+      <div className="flex flex-col h-screen bg-gray-900 md:pt-20">
         <div className="hidden md:block">
           <ChatHeader
             userName={user.username}
@@ -133,7 +133,7 @@ function App() {
   }
 
   return (
-    <div className="flex flex-col h-screen bg-gray-900">
+    <div className="flex flex-col h-screen bg-gray-900 pt-12 md:pt-20">
       <ChatHeader
         userName={user.username}
         onClearUser={signOut}

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -23,7 +23,7 @@ export function ChatHeader({ userName, onClearUser, onShowProfile, currentPage, 
   };
 
   return (
-    <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 sm:p-4 shadow-lg relative sticky top-0 z-50">
+    <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 sm:p-4 shadow-lg fixed top-0 left-0 right-0 z-50">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 sm:gap-6 sm:ml-8">
           {/* Logo */}

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -229,7 +229,7 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
   }
 
   return (
-    <div className="min-h-screen bg-gray-900 relative">
+    <div className="min-h-screen bg-gray-900 relative pt-12 md:pt-20">
       {/* Same header as main page */}
       <ChatHeader
         userName={user.username}


### PR DESCRIPTION
## Summary
- keep chat header fixed on all pages
- offset top padding for pages that use `ChatHeader`

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859881ad0e083279ba801e7bf2d4f6a