### PR TITLE
Fix mobile header slide by using 100vh

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -53,23 +53,21 @@
   padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
 }
 
+
 .h-screen {
-  height: 100dvh;
-  height: 100svh;
+  height: 100vh;
 }
 
 @supports (-webkit-touch-callout: none) {
   .h-screen {
     height: -webkit-fill-available;
-    height: 100dvh;
-    height: 100svh;
+    height: 100vh;
   }
 }
 
 @media screen and (max-width: 768px) {
   .h-\[calc\(100vh-5rem\)\] {
     height: calc(100vh - 5rem);
-    height: calc(100dvh - 5rem);
   }
   
   body {


### PR DESCRIPTION
## Summary
- keep `.h-screen` height fixed to 100vh so the header doesn't slide up when the keyboard opens
- update the mobile calc class to drop `100dvh`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68598a3754c08327ac0fd0941e27cbc5