### PR TITLE
Fix header disappearing when mobile keyboard opens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,7 +91,7 @@ function App() {
   // Show DMs page
   if (currentPage === 'dms') {
     return (
-      <div className="flex flex-col h-screen bg-gray-900 md:pt-20">
+      <div className="flex flex-col h-screen bg-gray-900">
         <div className="hidden md:block">
           <ChatHeader
             userName={user.username}
@@ -133,7 +133,7 @@ function App() {
   }
 
   return (
-    <div className="flex flex-col h-screen bg-gray-900 pt-12 md:pt-20">
+    <div className="flex flex-col h-screen bg-gray-900">
       <ChatHeader
         userName={user.username}
         onClearUser={signOut}

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -23,7 +23,7 @@ export function ChatHeader({ userName, onClearUser, onShowProfile, currentPage, 
   };
 
   return (
-    <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 sm:p-4 shadow-lg fixed top-0 left-0 right-0 z-50">
+    <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 sm:p-4 shadow-lg sticky top-0 left-0 right-0 z-50 safe-area-inset-top">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 sm:gap-6 sm:ml-8">
           {/* Logo */}

--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -500,7 +500,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
 
 
   return (
-    <div className="h-screen md:h-[calc(100vh-5rem)] overflow-hidden bg-gray-900">
+    <div className="h-screen md:h-screen overflow-hidden bg-gray-900">
       <div className="flex px-2 sm:px-8 lg:px-16 py-2 sm:py-6 h-full gap-2 sm:gap-6 relative min-h-0">
         {/* Contacts Sidebar */}
         <div className={`${

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -229,7 +229,7 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
   }
 
   return (
-    <div className="min-h-screen bg-gray-900 relative pt-12 md:pt-20">
+    <div className="min-h-screen bg-gray-900 relative">
       {/* Same header as main page */}
       <ChatHeader
         userName={user.username}
@@ -250,7 +250,7 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
       </div>
 
       {/* Main content with grid layout */}
-      <div className="h-[calc(100vh-5rem)] overflow-hidden">
+      <div className="h-screen overflow-hidden">
         <div className="flex justify-start px-4 sm:px-8 lg:px-16 py-4 sm:py-6 h-full">
           
           {/* Profile Card - Left side */}

--- a/src/index.css
+++ b/src/index.css
@@ -53,6 +53,10 @@
   padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
 }
 
+.safe-area-inset-top {
+  padding-top: env(safe-area-inset-top);
+}
+
 
 .h-screen {
   height: 100dvh;


### PR DESCRIPTION
## Summary
- keep chat header sticky instead of fixed and pad for safe area
- update layouts to remove fixed-header padding
- apply safe-area top CSS

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68599a2e83f08327826c4c7437c69951