### PR TITLE
Fix mobile header scroll on iOS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+html, body, #root {
+  height: 100%;
+}
+
+body {
+  overflow: hidden;
+  overscroll-behavior-y: contain;
+}
+
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;


### PR DESCRIPTION
## Summary
- prevent the body from scrolling when the keyboard appears
- set html, body, and `#root` to full height

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859a744ec148327a412795b68e12e96