### PR TITLE
Fix header position for mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,7 +91,7 @@ function App() {
   // Show DMs page
   if (currentPage === 'dms') {
     return (
-      <div className="flex flex-col h-screen bg-gray-900 overflow-hidden">
+      <div className="flex flex-col h-screen bg-gray-900 overflow-hidden pt-12 md:pt-0">
         <div className="hidden md:block">
           <ChatHeader
             userName={user.username}
@@ -133,7 +133,7 @@ function App() {
   }
 
   return (
-    <div className="flex flex-col h-screen bg-gray-900 overflow-hidden">
+    <div className="flex flex-col h-screen bg-gray-900 overflow-hidden pt-12 md:pt-0">
       <ChatHeader
         userName={user.username}
         onClearUser={signOut}

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -23,7 +23,7 @@ export function ChatHeader({ userName, onClearUser, onShowProfile, currentPage, 
   };
 
   return (
-    <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 sm:p-4 shadow-lg sticky top-0 left-0 right-0 z-50 safe-area-inset-top">
+    <div className="bg-gray-800 border-b border-gray-700 px-4 py-2 sm:p-4 shadow-lg fixed sm:sticky top-0 left-0 right-0 z-50 safe-area-inset-top">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2 sm:gap-6 sm:ml-8">
           {/* Logo */}

--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -500,7 +500,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
 
 
   return (
-    <div className="h-screen md:h-screen overflow-hidden bg-gray-900">
+    <div className="h-screen md:h-screen overflow-hidden bg-gray-900 pt-12 md:pt-0">
       <div className="flex px-2 sm:px-8 lg:px-16 py-2 sm:py-6 h-full gap-2 sm:gap-6 relative min-h-0">
         {/* Contacts Sidebar */}
         <div className={`${

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -222,14 +222,14 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-900 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-900 flex items-center justify-center pt-12 md:pt-0">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-900 relative">
+    <div className="min-h-screen bg-gray-900 relative pt-12 md:pt-0">
       {/* Same header as main page */}
       <ChatHeader
         userName={user.username}

--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,6 @@ html, body, #root {
 }
 
 body {
-  overflow: hidden;
   overscroll-behavior-y: contain;
 }
 


### PR DESCRIPTION
## Summary
- keep the chat header fixed on small screens
- offset page content for new header height
- allow page scroll by removing body overflow rule

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6859bd78d6e88327b248b260b72964f3