### PR TITLE
use shared avatarColors for random color

### DIFF
--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { User, Mail, Lock, Eye, EyeOff } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import type { AuthUser } from '../hooks/useAuth';
+import { avatarColors } from '../utils/avatarColors';
 
 interface AuthFormProps {
   onAuthSuccess: (user: AuthUser) => void;
@@ -95,12 +96,7 @@ export function AuthForm({ onAuthSuccess }: AuthFormProps) {
   };
 
   const getRandomColor = () => {
-    const colors = [
-      '#EF4444', '#F97316', '#F59E0B', '#84CC16', 
-      '#22C55E', '#06B6D4', '#3B82F6', '#6366F1', 
-      '#8B5CF6', '#EC4899', '#F43F5E', '#64748B'
-    ];
-    return colors[Math.floor(Math.random() * colors.length)];
+    return avatarColors[Math.floor(Math.random() * avatarColors.length)];
   };
 
   return (


### PR DESCRIPTION
## Summary
- use centralized avatarColors constant in AuthForm

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685a0c06e9fc83279850add55f8c6a82