### PR TITLE
Centralize presence update helper

### DIFF
--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { Search, MessageSquare, Send, X, Clock, Users, ArrowLeft } from 'lucide-react';
 import { Smile } from 'lucide-react';
 import { supabase } from '../lib/supabase';
+import { updatePresence } from '../utils/updatePresence';
 import { useToast } from './Toast';
 
 interface User {
@@ -77,13 +78,6 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
   const [showReactionPicker, setShowReactionPicker] = useState<string | null>(null);
   const [isReacting, setIsReacting] = useState(false);
   const { show } = useToast();
-  const updatePresence = async () => {
-    try {
-      await supabase.rpc('update_user_last_active');
-    } catch (err) {
-      console.error('Failed to update presence', err);
-    }
-  };
 
   const getConversationWithUser = useCallback(
     (userId: string) =>

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { supabase } from '../lib/supabase';
+import { updatePresence } from '../utils/updatePresence';
 import { Message } from '../types/message';
 
 const PAGE_SIZE = 20;
@@ -89,13 +90,6 @@ export function useMessages(userId: string | null) {
     };
   }, [userId]);
 
-  const updatePresence = async () => {
-    try {
-      await supabase.rpc('update_user_last_active');
-    } catch (err) {
-      console.error('Failed to update last_active', err);
-    }
-  };
 
   const fetchLatestMessages = async () => {
     try {

--- a/src/hooks/usePresence.ts
+++ b/src/hooks/usePresence.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { supabase } from '../lib/supabase';
+import { updatePresence } from '../utils/updatePresence';
 
 const INTERVAL = Number(import.meta.env.VITE_PRESENCE_INTERVAL_MS) || 30000;
 
@@ -7,13 +8,6 @@ export function usePresence() {
   const [activeUserIds, setActiveUserIds] = useState<string[]>([]);
   const intervalRef = useRef<number | null>(null);
 
-  const updatePresence = async () => {
-    try {
-      await supabase.rpc('update_user_last_active');
-    } catch (err) {
-      console.error('Failed to update last_active', err);
-    }
-  };
 
   useEffect(() => {
     updatePresence();

--- a/src/utils/updatePresence.ts
+++ b/src/utils/updatePresence.ts
@@ -1,0 +1,5 @@
+import { supabase } from '../lib/supabase';
+
+export async function updatePresence(): Promise<void> {
+  await supabase.rpc('update_user_last_active');
+}


### PR DESCRIPTION
## Summary
- create `updatePresence` helper
- use `updatePresence` in `DMsPage`, `useMessages` and `usePresence`

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685a0c1025108327b6c29eda4862fe33