### PR TITLE
Fix reload listeners

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,33 +1,49 @@
-import { StrictMode } from 'react';
+import { StrictMode, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import { ToastProvider } from './components/Toast';
 import './index.css';
 
-// Reload the entire page whenever the tab regains focus after being
-// backgrounded. This helps recover when the app becomes flaky after a
-// long period of inactivity.
-let hasFocusedOnce = document.hasFocus();
+// Component responsible for setting up focus/visibility event listeners.
+function Root() {
+  useEffect(() => {
+    // Reload the entire page whenever the tab regains focus after being
+    // backgrounded. This helps recover when the app becomes flaky after a
+    // long period of inactivity.
+    let hasFocusedOnce = document.hasFocus();
 
-const reloadOnFocus = () => {
-  if (hasFocusedOnce) {
-    window.location.reload();
-  } else {
-    hasFocusedOnce = true;
-  }
-};
+    const reloadOnFocus = () => {
+      if (hasFocusedOnce) {
+        window.location.reload();
+      } else {
+        hasFocusedOnce = true;
+      }
+    };
 
-window.addEventListener('focus', reloadOnFocus);
-document.addEventListener('visibilitychange', () => {
-  if (document.visibilityState === 'visible') {
-    reloadOnFocus();
-  }
-});
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        reloadOnFocus();
+      }
+    };
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
+    window.addEventListener('focus', reloadOnFocus);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener('focus', reloadOnFocus);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
+  return (
     <ToastProvider>
       <App />
     </ToastProvider>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <Root />
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- move reload listeners into a React component effect
- clean up listeners on unmount

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685a0c29e47c832795f0c52802325fa2