### PR TITLE
Fix sidebar reloading on conversation change

### DIFF
--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -297,7 +297,6 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
       cleanupConnections();
     };
   }, [
-    selectedConversation?.id,
     fetchCurrentUserData,
     fetchUsers,
     fetchConversations,


### PR DESCRIPTION
## Summary
- keep the data fetching effect from re-running when the selected conversation changes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a0e4dd2a48327ad59516aafb75532