### PR TITLE
Move DM messages to own table

### DIFF
--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -143,6 +143,84 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
     }
   }, []);
 
+  const oldestTimestampRef = useRef<string | null>(null);
+  const hasMoreRef = useRef(true);
+  const loadingOlderRef = useRef(false);
+
+  const fetchConversationMessages = useCallback(
+    async (conversationId: string) => {
+      try {
+        const { data, error } = await supabase
+          .from('dm_messages')
+          .select('id, sender_id, content, created_at, reactions')
+          .eq('conversation_id', conversationId)
+          .order('created_at', { ascending: false })
+          .limit(DM_PAGE_SIZE);
+
+        if (error) throw error;
+
+        const sorted = [...(data || [])].reverse();
+        oldestTimestampRef.current = sorted.length > 0 ? sorted[0].created_at : null;
+        hasMoreRef.current = (data || []).length === DM_PAGE_SIZE;
+
+        setConversations(prev =>
+          prev.map(conv =>
+            conv.id === conversationId ? { ...conv, messages: sorted } : conv
+          )
+        );
+
+        if (selectedConversation?.id === conversationId) {
+          setSelectedConversation(conv =>
+            conv ? { ...conv, messages: sorted } : null
+          );
+          setMessageLimit(Math.min(DM_PAGE_SIZE, sorted.length));
+        }
+      } catch (err) {
+        console.error('Error fetching DM messages:', err);
+      }
+    },
+    [selectedConversation]
+  );
+
+  const fetchOlderMessages = useCallback(async () => {
+    if (!selectedConversation || !oldestTimestampRef.current || !hasMoreRef.current || loadingOlderRef.current) return;
+
+    loadingOlderRef.current = true;
+    try {
+      const { data, error } = await supabase
+        .from('dm_messages')
+        .select('id, sender_id, content, created_at, reactions')
+        .eq('conversation_id', selectedConversation.id)
+        .lt('created_at', oldestTimestampRef.current)
+        .order('created_at', { ascending: false })
+        .limit(DM_PAGE_SIZE);
+
+      if (error) throw error;
+
+      const sorted = [...(data || [])].reverse();
+      if (sorted.length > 0) {
+        oldestTimestampRef.current = sorted[0].created_at;
+      }
+      hasMoreRef.current = (data || []).length === DM_PAGE_SIZE;
+
+      setSelectedConversation(conv =>
+        conv ? { ...conv, messages: [...sorted, ...conv.messages] } : null
+      );
+      setConversations(prev =>
+        prev.map(c =>
+          c.id === selectedConversation.id
+            ? { ...c, messages: [...sorted, ...(c.messages || [])] }
+            : c
+        )
+      );
+      setMessageLimit(limit => limit + sorted.length);
+    } catch (err) {
+      console.error('Error fetching older DM messages:', err);
+    } finally {
+      loadingOlderRef.current = false;
+    }
+  }, [selectedConversation]);
+
   const setupRealtimeSubscription = useCallback(() => {
     cleanupConnections();
 
@@ -175,6 +253,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
             // Update selected conversation if it's the same one
             if (selectedConversation?.id === updatedConversation.id) {
               setSelectedConversation(updatedConversation);
+              fetchConversationMessages(updatedConversation.id);
             }
           }
         }
@@ -182,7 +261,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
       .subscribe();
 
     channelRef.current = channel;
-  }, [cleanupConnections, selectedConversation?.id, currentUser.id]);
+  }, [cleanupConnections, selectedConversation?.id, currentUser.id, fetchConversationMessages]);
 
   // Handle scroll detection to prevent auto-scroll when user is manually scrolling
   const handleScroll = useCallback(() => {
@@ -199,26 +278,19 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
       isUserScrollingRef.current = false;
     }, 1000);
 
-    if (
-      container.scrollTop === 0 &&
-      messageLimit < selectedConversation.messages.length &&
-      !isLoadingMoreRef.current
-    ) {
+    if (container.scrollTop === 0 && hasMoreRef.current && !isLoadingMoreRef.current) {
       const previousHeight = container.scrollHeight;
       isLoadingMoreRef.current = true;
-      setMessageLimit((limit) =>
-        Math.min(limit + DM_PAGE_SIZE, selectedConversation.messages.length)
-      );
 
-      setTimeout(() => {
+      fetchOlderMessages().then(() => {
         requestAnimationFrame(() => {
           const newHeight = container.scrollHeight;
           container.scrollTop = newHeight - previousHeight;
           isLoadingMoreRef.current = false;
         });
-      }, 100);
+      });
     }
-  }, [messageLimit, selectedConversation]);
+  }, [selectedConversation, fetchOlderMessages]);
 
   const fetchCurrentUserData = useCallback(async () => {
     try {
@@ -257,7 +329,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
 
       const { data, error } = await supabase
         .from('dms')
-        .select('*')
+        .select('id, user1_id, user2_id, user1_username, user2_username, updated_at')
         .or(`user1_id.eq.${currentUser.id},user2_id.eq.${currentUser.id}`)
         .order('updated_at', { ascending: false });
 
@@ -272,19 +344,22 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
   }, [currentUser.id]);
 
   useEffect(() => {
-    if (initialConversationId && conversations.length > 0 && !selectedConversation) {
-      const conv = conversations.find(c => c.id === initialConversationId);
-      if (conv) {
-        const normalized = normalizeConversation(conv);
-        setSelectedConversation(normalized);
-        setMessageLimit(Math.min(DM_PAGE_SIZE, normalized.messages.length));
-        hasAutoScrolledRef.current = false;
-        if (onConversationOpen) {
-          onConversationOpen(normalized.id, normalized.updated_at);
+    const openInitial = async () => {
+      if (initialConversationId && conversations.length > 0 && !selectedConversation) {
+        const conv = conversations.find(c => c.id === initialConversationId);
+        if (conv) {
+          const normalized = normalizeConversation(conv);
+          setSelectedConversation({ ...normalized, messages: [] });
+          await fetchConversationMessages(normalized.id);
+          hasAutoScrolledRef.current = false;
+          if (onConversationOpen) {
+            onConversationOpen(normalized.id, normalized.updated_at);
+          }
         }
       }
-    }
-  }, [initialConversationId, conversations, selectedConversation, onConversationOpen]);
+    };
+    openInitial();
+  }, [initialConversationId, conversations, selectedConversation, onConversationOpen, fetchConversationMessages]);
 
   useEffect(() => {
     fetchCurrentUserData();
@@ -391,15 +466,15 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
       // Fetch the conversation
       const { data: conversation, error: fetchError } = await supabase
         .from('dms')
-        .select('*')
+        .select('id, user1_id, user2_id, user1_username, user2_username, updated_at')
         .eq('id', conversationId)
         .single();
 
       if (fetchError) throw fetchError;
 
       const normalized = normalizeConversation(conversation);
-      setSelectedConversation(normalized);
-      setMessageLimit(Math.min(DM_PAGE_SIZE, normalized.messages.length));
+      setSelectedConversation({ ...normalized, messages: [] });
+      await fetchConversationMessages(normalized.id);
       hasAutoScrolledRef.current = false;
       if (onConversationOpen) {
         onConversationOpen(normalized.id, normalized.updated_at);
@@ -583,9 +658,9 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                         return (
                           <button
                             key={conversation.id}
-                            onClick={() => {
-                              setSelectedConversation(conversation);
-                              setMessageLimit(Math.min(DM_PAGE_SIZE, conversation.messages.length));
+                            onClick={async () => {
+                              setSelectedConversation({ ...conversation, messages: [] });
+                              await fetchConversationMessages(conversation.id);
                               hasAutoScrolledRef.current = false;
                               if (onConversationOpen) {
                                 onConversationOpen(

--- a/supabase/migrations/20250624023500_garnet_star.sql
+++ b/supabase/migrations/20250624023500_garnet_star.sql
@@ -1,0 +1,94 @@
+/*
+  # Move DM messages to separate table
+
+  1. Tables
+    - Create dm_messages table
+      - id uuid primary key
+      - conversation_id uuid references dms(id) on delete cascade
+      - sender_id uuid references users(id)
+      - content text
+      - created_at timestamptz default now()
+      - reactions jsonb default '{}'
+    - Index on conversation_id
+    - Index on created_at
+
+  2. Functions
+    - Update append_dm_message and toggle_dm_reaction to use dm_messages
+*/
+
+-- Create table for DM messages
+CREATE TABLE IF NOT EXISTS dm_messages (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  conversation_id uuid NOT NULL REFERENCES dms(id) ON DELETE CASCADE,
+  sender_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  content text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  reactions jsonb DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS dm_messages_conversation_id_idx ON dm_messages(conversation_id);
+CREATE INDEX IF NOT EXISTS dm_messages_created_at_idx ON dm_messages(created_at DESC);
+
+-- Replace append_dm_message to insert into dm_messages
+DROP FUNCTION IF EXISTS append_dm_message(uuid, uuid, text);
+CREATE OR REPLACE FUNCTION append_dm_message(
+  conversation_id uuid,
+  sender_id uuid,
+  message_text text
+)
+RETURNS void AS $$
+BEGIN
+  INSERT INTO dm_messages (conversation_id, sender_id, content)
+  VALUES (conversation_id, sender_id, message_text);
+  UPDATE dms SET updated_at = now() WHERE id = conversation_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Replace toggle_dm_reaction for new table structure
+DROP FUNCTION IF EXISTS toggle_dm_reaction(uuid, text, text, text);
+CREATE OR REPLACE FUNCTION toggle_dm_reaction(
+  conversation_id uuid,
+  message_id uuid,
+  user_id uuid,
+  emoji text
+) RETURNS void AS $$
+DECLARE
+  current_reactions jsonb;
+  emoji_users jsonb;
+  user_exists boolean;
+BEGIN
+  SELECT COALESCE(reactions, '{}'::jsonb) INTO current_reactions
+  FROM dm_messages
+  WHERE id = message_id AND conversation_id = conversation_id;
+
+  emoji_users := COALESCE(current_reactions -> emoji, '[]'::jsonb);
+
+  SELECT EXISTS(
+    SELECT 1 FROM jsonb_array_elements_text(emoji_users) AS u
+    WHERE u = user_id::text
+  ) INTO user_exists;
+
+  IF user_exists THEN
+    emoji_users := (
+      SELECT COALESCE(jsonb_agg(u), '[]'::jsonb)
+      FROM jsonb_array_elements_text(emoji_users) AS u
+      WHERE u <> user_id::text
+    );
+    IF jsonb_array_length(emoji_users) = 0 THEN
+      current_reactions := current_reactions - emoji;
+    ELSE
+      current_reactions := jsonb_set(current_reactions, ARRAY[emoji], emoji_users);
+    END IF;
+  ELSE
+    emoji_users := emoji_users || jsonb_build_array(user_id::text);
+    current_reactions := jsonb_set(current_reactions, ARRAY[emoji], emoji_users);
+  END IF;
+
+  UPDATE dm_messages
+  SET reactions = current_reactions
+  WHERE id = message_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION append_dm_message(uuid, uuid, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION toggle_dm_reaction(uuid, uuid, uuid, text) TO authenticated;


### PR DESCRIPTION
## Summary
- create `dm_messages` table for individual DM rows
- update RPCs for inserting and reacting to DM messages
- fetch DM conversations without messages
- load DM messages from new table with pagination

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a0e52bd408327a30614dbd4bdf48a