### PR TITLE
Refactor profile components

### DIFF
--- a/src/components/AvatarUpload.tsx
+++ b/src/components/AvatarUpload.tsx
@@ -1,0 +1,187 @@
+import React, { useState } from 'react';
+import { Upload, X } from 'lucide-react';
+import { supabase } from '../lib/supabase';
+
+interface AvatarUploadProps {
+  userId: string;
+  type: 'avatar' | 'banner';
+  imageUrl: string;
+  username: string;
+  avatarColor?: string;
+  onChange: (url: string) => void;
+  onError?: (msg: string) => void;
+}
+
+export function AvatarUpload({
+  userId,
+  type,
+  imageUrl,
+  username,
+  avatarColor,
+  onChange,
+  onError
+}: AvatarUploadProps) {
+  const [uploading, setUploading] = useState(false);
+
+  const uploadImage = async (file: File): Promise<string> => {
+    const fileExt = file.name.split('.').pop();
+    const fileName = `${userId}/${type}_${Date.now()}.${fileExt}`;
+
+    const { error } = await supabase.storage
+      .from('images')
+      .upload(fileName, file, {
+        cacheControl: '3600',
+        upsert: false
+      });
+
+    if (error) throw error;
+
+    const {
+      data: { publicUrl }
+    } = supabase.storage.from('images').getPublicUrl(fileName);
+
+    return publicUrl;
+  };
+
+  const handleFile = async (file: File) => {
+    if (!file) return;
+
+    if (!file.type.startsWith('image/')) {
+      onError?.('Please select a valid image file');
+      return;
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+      onError?.('Image size must be less than 5MB');
+      return;
+    }
+
+    try {
+      setUploading(true);
+      onError?.(null as unknown as string); // clear any previous error
+      const url = await uploadImage(file);
+      onChange(url);
+    } catch (err) {
+      onError?.(
+        err instanceof Error ? err.message : `Failed to upload ${type}`
+      );
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const inputId = `${type}-upload`;
+
+  if (type === 'banner') {
+    return (
+      <div>
+        <label className="block text-sm font-medium text-gray-200 mb-2">
+          Banner Image
+        </label>
+        <div className="relative">
+          <div
+            className="w-full h-24 sm:h-32 bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg overflow-hidden cursor-pointer hover:opacity-80 transition-opacity border-2 border-dashed border-gray-600 hover:border-gray-400"
+            style={
+              imageUrl
+                ? {
+                    backgroundImage: `url(${imageUrl})`,
+                    backgroundSize: 'cover',
+                    backgroundPosition: 'center',
+                    border: 'none'
+                  }
+                : {}
+            }
+            onClick={() => document.getElementById(inputId)?.click()}
+          >
+            {!imageUrl && (
+              <div className="flex items-center justify-center h-full">
+                <div className="text-center text-white">
+                  <Upload className="w-6 h-6 sm:w-8 sm:h-8 mx-auto mb-2" />
+                  <p className="text-xs sm:text-sm">Click to upload banner</p>
+                </div>
+              </div>
+            )}
+            {uploading && (
+              <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
+              </div>
+            )}
+          </div>
+          <input
+            id={inputId}
+            type="file"
+            accept="image/*"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) handleFile(file);
+            }}
+            className="hidden"
+          />
+          {imageUrl && (
+            <button
+              onClick={() => onChange('')}
+              className="absolute top-2 right-2 p-1 bg-red-600 hover:bg-red-700 text-white rounded-full transition-colors"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-200 mb-2">
+        Profile Picture
+      </label>
+      <div className="flex flex-col sm:flex-row items-center gap-4">
+        <div className="relative">
+          <div
+            className="w-20 h-20 sm:w-24 sm:h-24 rounded-full overflow-hidden cursor-pointer hover:opacity-80 transition-opacity border-2 border-dashed border-gray-600 hover:border-gray-400 flex items-center justify-center"
+            style={imageUrl ? { border: 'none' } : {}}
+            onClick={() => document.getElementById(inputId)?.click()}
+          >
+            {imageUrl ? (
+              <img
+                src={imageUrl}
+                alt="Avatar preview"
+                className="w-full h-full object-cover"
+              />
+            ) : (
+              <div
+                className="w-full h-full flex items-center justify-center text-white text-lg sm:text-xl font-bold"
+                style={{ backgroundColor: avatarColor }}
+              >
+                {username.charAt(0).toUpperCase()}
+              </div>
+            )}
+            {uploading && (
+              <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
+              </div>
+            )}
+          </div>
+          <input
+            id={inputId}
+            type="file"
+            accept="image/*"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) handleFile(file);
+            }}
+            className="hidden"
+          />
+          {imageUrl && (
+            <button
+              onClick={() => onChange('')}
+              className="absolute top-2 right-2 p-1 bg-red-600 hover:bg-red-700 text-white rounded-full transition-colors"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -1,0 +1,198 @@
+import React, { useState } from 'react';
+import { User, Palette, Save } from 'lucide-react';
+import { supabase } from '../lib/supabase';
+import { avatarColors } from '../utils/avatarColors';
+import { AvatarUpload } from './AvatarUpload';
+
+interface ProfileFormProps {
+  user: {
+    id: string;
+    email: string;
+    username: string;
+    avatar_color: string;
+  };
+  initialData: {
+    username: string;
+    bio: string;
+    avatar_color: string;
+    avatar_url: string;
+    banner_url: string;
+  };
+  onCancel: () => void;
+  onSaved: (updated: {
+    username: string;
+    bio: string;
+    avatar_color: string;
+    avatar_url: string;
+    banner_url: string;
+  }) => void;
+}
+
+export function ProfileForm({ user, initialData, onCancel, onSaved }: ProfileFormProps) {
+  const [editData, setEditData] = useState(initialData);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleSave = async () => {
+    if (!editData.username.trim()) {
+      setError('Username is required');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const { data: existingUsers } = await supabase
+        .from('users')
+        .select('id')
+        .eq('username', editData.username.trim())
+        .neq('id', user.id)
+        .limit(1);
+
+      if (existingUsers && existingUsers.length > 0) {
+        throw new Error('Username is already taken');
+      }
+
+      const { error } = await supabase
+        .from('users')
+        .update({
+          username: editData.username.trim(),
+          bio: editData.bio.trim(),
+          avatar_color: editData.avatar_color,
+          avatar_url: editData.avatar_url.trim() || null,
+          banner_url: editData.banner_url.trim() || null
+        })
+        .eq('id', user.id);
+
+      if (error) throw error;
+
+      setSuccess(true);
+      onSaved({
+        ...editData,
+        username: editData.username.trim(),
+        bio: editData.bio.trim()
+      });
+      setTimeout(() => {
+        setSuccess(false);
+        onCancel();
+      }, 2000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update profile');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="p-4 sm:p-6 space-y-4 sm:space-y-6">
+      <AvatarUpload
+        userId={user.id}
+        type="banner"
+        imageUrl={editData.banner_url}
+        username={editData.username}
+        onChange={(url) => setEditData({ ...editData, banner_url: url })}
+        onError={setError}
+      />
+
+      <AvatarUpload
+        userId={user.id}
+        type="avatar"
+        imageUrl={editData.avatar_url}
+        username={editData.username}
+        avatarColor={editData.avatar_color}
+        onChange={(url) => setEditData({ ...editData, avatar_url: url })}
+        onError={setError}
+      />
+
+      <div>
+        <label className="block text-sm font-medium text-gray-200 mb-2">
+          Username
+        </label>
+        <div className="relative">
+          <User className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
+          <input
+            type="text"
+            value={editData.username}
+            onChange={(e) => setEditData({ ...editData, username: e.target.value })}
+            className="w-full pl-10 pr-4 py-3 bg-gray-700 border border-gray-600 text-white rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all duration-200 placeholder-gray-400"
+            placeholder="Enter username"
+            maxLength={30}
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-200 mb-2">Bio</label>
+        <textarea
+          value={editData.bio}
+          onChange={(e) => setEditData({ ...editData, bio: e.target.value })}
+          className="w-full px-4 py-3 bg-gray-700 border border-gray-600 text-white rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all duration-200 placeholder-gray-400 resize-none"
+          placeholder="Tell us about yourself..."
+          rows={2}
+          maxLength={200}
+        />
+        <p className="text-xs text-gray-400 mt-1">{editData.bio.length}/200 characters</p>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-200 mb-2">
+          <Palette className="inline w-4 h-4 mr-1" /> Avatar Color
+        </label>
+        <div className="grid grid-cols-4 sm:grid-cols-6 gap-2 sm:gap-3">
+          {avatarColors.map((color) => (
+            <button
+              key={color}
+              onClick={() => setEditData({ ...editData, avatar_color: color })}
+              className={`w-10 h-10 sm:w-12 sm:h-12 rounded-full border-2 transition-all ${
+                editData.avatar_color === color
+                  ? 'border-white scale-110'
+                  : 'border-gray-600 hover:border-gray-400'
+              }`}
+              style={{ backgroundColor: color }}
+            />
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-red-900/50 border border-red-700 text-red-200 px-4 py-3 rounded-lg text-sm">
+          {error}
+        </div>
+      )}
+
+      {success && (
+        <div className="bg-green-900/50 border border-green-700 text-green-200 px-4 py-3 rounded-lg text-sm">
+          Profile updated successfully!
+        </div>
+      )}
+
+      <div className="flex flex-col sm:flex-row gap-3 pt-4">
+        <button
+          onClick={onCancel}
+          className="flex-1 px-4 py-3 bg-gray-700 text-white rounded-lg hover:bg-gray-600 transition-colors order-2 sm:order-1"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className="flex-1 bg-gradient-to-r from-blue-600 to-purple-600 text-white py-3 px-6 rounded-lg font-medium hover:from-blue-700 hover:to-purple-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-800 transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98] shadow-lg disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none order-1 sm:order-2"
+        >
+          {saving ? (
+            <div className="flex items-center justify-center">
+              <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></div>
+              Saving...
+            </div>
+          ) : (
+            <div className="flex items-center justify-center gap-2">
+              <Save className="w-5 h-5" />
+              Save Changes
+            </div>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { X, User, Mail, Palette, Save, Upload, ArrowLeft } from 'lucide-react';
+import { X, Mail, ArrowLeft } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { ChatHeader } from './ChatHeader';
-import { avatarColors } from '../utils/avatarColors';
+import { ProfileForm } from './ProfileForm';
 
 type PageType = 'group-chat' | 'dms' | 'profile';
 
@@ -41,19 +41,6 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
   const [loading, setLoading] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
 
-  // Edit modal state
-  const [editData, setEditData] = useState({
-    username: user.username,
-    bio: '',
-    avatar_color: user.avatar_color,
-    avatar_url: '',
-    banner_url: '',
-  });
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState(false);
-  const [uploadingAvatar, setUploadingAvatar] = useState(false);
-  const [uploadingBanner, setUploadingBanner] = useState(false);
 
   useEffect(() => {
     fetchUserProfile();
@@ -80,7 +67,6 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
           created_at: data.created_at || '',
         };
         setProfileData(profile);
-        setEditData(profile);
       }
     } catch (err) {
       console.error('Error fetching profile:', err);
@@ -89,127 +75,6 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
     }
   };
 
-  const handleSave = async () => {
-    if (!editData.username.trim()) {
-      setError('Username is required');
-      return;
-    }
-
-    setSaving(true);
-    setError(null);
-
-    try {
-      // Check if username is taken by another user
-      const { data: existingUsers } = await supabase
-        .from('users')
-        .select('id')
-        .eq('username', editData.username.trim())
-        .neq('id', user.id)
-        .limit(1);
-
-      if (existingUsers && existingUsers.length > 0) {
-        throw new Error('Username is already taken');
-      }
-
-      const { error } = await supabase
-        .from('users')
-        .update({
-          username: editData.username.trim(),
-          bio: editData.bio.trim(),
-          avatar_color: editData.avatar_color,
-          avatar_url: editData.avatar_url.trim() || null,
-          banner_url: editData.banner_url.trim() || null,
-        })
-        .eq('id', user.id);
-
-      if (error) throw error;
-
-      // Update local state
-      setProfileData({
-        ...profileData,
-        ...editData,
-        username: editData.username.trim(),
-        bio: editData.bio.trim(),
-      });
-
-      // Update the user in the parent component
-      onUserUpdate({
-        ...user,
-        username: editData.username.trim(),
-        avatar_color: editData.avatar_color,
-      });
-
-      setSuccess(true);
-      setTimeout(() => {
-        setSuccess(false);
-        setShowEditModal(false);
-      }, 2000);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to update profile');
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const uploadImage = async (file: File, type: 'avatar' | 'banner'): Promise<string> => {
-    const fileExt = file.name.split('.').pop();
-    const fileName = `${user.id}/${type}_${Date.now()}.${fileExt}`;
-    
-    const { error } = await supabase.storage
-      .from('images')
-      .upload(fileName, file, {
-        cacheControl: '3600',
-        upsert: false
-      });
-
-    if (error) throw error;
-
-    const { data: { publicUrl } } = supabase.storage
-      .from('images')
-      .getPublicUrl(fileName);
-
-    return publicUrl;
-  };
-
-  const handleImageUpload = async (file: File, type: 'avatar' | 'banner') => {
-    if (!file) return;
-
-    // Validate file type
-    if (!file.type.startsWith('image/')) {
-      setError('Please select a valid image file');
-      return;
-    }
-
-    // Validate file size (max 5MB)
-    if (file.size > 5 * 1024 * 1024) {
-      setError('Image size must be less than 5MB');
-      return;
-    }
-
-    try {
-      if (type === 'avatar') {
-        setUploadingAvatar(true);
-      } else {
-        setUploadingBanner(true);
-      }
-      
-      setError(null);
-      const imageUrl = await uploadImage(file, type);
-      
-      setEditData({
-        ...editData,
-        [type === 'avatar' ? 'avatar_url' : 'banner_url']: imageUrl
-      });
-    } catch (err) {
-      setError(err instanceof Error ? err.message : `Failed to upload ${type}`);
-    } finally {
-      if (type === 'avatar') {
-        setUploadingAvatar(false);
-      } else {
-        setUploadingBanner(false);
-      }
-    }
-  };
 
   const formatJoinDate = (dateString: string) => {
     if (!dateString) return 'Unknown';
@@ -342,213 +207,20 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
               </button>
             </div>
 
-            {/* Modal Content */}
-            <div className="p-4 sm:p-6 space-y-4 sm:space-y-6">
-              {/* Banner Preview & Upload */}
-              <div>
-                <label className="block text-sm font-medium text-gray-200 mb-2">
-                  Banner Image
-                </label>
-                <div className="relative">
-                  <div 
-                    className="w-full h-24 sm:h-32 bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg overflow-hidden cursor-pointer hover:opacity-80 transition-opacity border-2 border-dashed border-gray-600 hover:border-gray-400"
-                    style={editData.banner_url ? { 
-                      backgroundImage: `url(${editData.banner_url})`,
-                      backgroundSize: 'cover',
-                      backgroundPosition: 'center',
-                      border: 'none'
-                    } : {}}
-                    onClick={() => document.getElementById('banner-upload')?.click()}
-                  >
-                    {!editData.banner_url && (
-                      <div className="flex items-center justify-center h-full">
-                        <div className="text-center text-white">
-                          <Upload className="w-6 h-6 sm:w-8 sm:h-8 mx-auto mb-2" />
-                          <p className="text-xs sm:text-sm">Click to upload banner</p>
-                        </div>
-                      </div>
-                    )}
-                    {uploadingBanner && (
-                      <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
-                        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
-                      </div>
-                    )}
-                  </div>
-                  <input
-                    id="banner-upload"
-                    type="file"
-                    accept="image/*"
-                    onChange={(e) => {
-                      const file = e.target.files?.[0];
-                      if (file) handleImageUpload(file, 'banner');
-                    }}
-                    className="hidden"
-                  />
-                  {editData.banner_url && (
-                    <button
-                      onClick={() => setEditData({ ...editData, banner_url: '' })}
-                      className="absolute top-2 right-2 p-1 bg-red-600 hover:bg-red-700 text-white rounded-full transition-colors"
-                    >
-                      <X className="w-4 h-4" />
-                    </button>
-                  )}
-                </div>
-              </div>
-
-              {/* Avatar Preview & Upload */}
-              <div>
-                <label className="block text-sm font-medium text-gray-200 mb-2">
-                  Profile Picture
-                </label>
-                <div className="flex flex-col sm:flex-row items-center gap-4">
-                  <div className="relative">
-                    <div 
-                      className="w-20 h-20 sm:w-24 sm:h-24 rounded-full overflow-hidden cursor-pointer hover:opacity-80 transition-opacity border-2 border-dashed border-gray-600 hover:border-gray-400 flex items-center justify-center"
-                      style={editData.avatar_url ? { border: 'none' } : {}}
-                      onClick={() => document.getElementById('avatar-upload')?.click()}
-                    >
-                      {editData.avatar_url ? (
-                        <img
-                          src={editData.avatar_url}
-                          alt="Avatar preview"
-                          className="w-full h-full object-cover"
-                        />
-                      ) : (
-                        <div 
-                          className="w-full h-full flex items-center justify-center text-white text-lg sm:text-xl font-bold"
-                          style={{ backgroundColor: editData.avatar_color }}
-                        >
-                          {editData.username.charAt(0).toUpperCase()}
-                        </div>
-                      )}
-                      {uploadingAvatar && (
-                        <div className="absolute inset-0 bg-black/50 flex items-center justify-center rounded-full">
-                          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-white"></div>
-                        </div>
-                      )}
-                    </div>
-                    <input
-                      id="avatar-upload"
-                      type="file"
-                      accept="image/*"
-                      onChange={(e) => {
-                        const file = e.target.files?.[0];
-                        if (file) handleImageUpload(file, 'avatar');
-                      }}
-                      className="hidden"
-                    />
-                    {editData.avatar_url && (
-                      <button
-                        onClick={() => setEditData({ ...editData, avatar_url: '' })}
-                        className="absolute -top-1 -right-1 p-1 bg-red-600 hover:bg-red-700 text-white rounded-full transition-colors"
-                      >
-                        <X className="w-3 h-3" />
-                      </button>
-                    )}
-                  </div>
-                  <div className="flex-1">
-                    <p className="text-xs sm:text-sm text-gray-300 mb-2 text-center sm:text-left">Click the avatar to upload a custom image</p>
-                    <p className="text-xs text-gray-400 text-center sm:text-left">Recommended: Square image, max 5MB</p>
-                  </div>
-                </div>
-              </div>
-
-              {/* Username */}
-              <div>
-                <label className="block text-sm font-medium text-gray-200 mb-2">
-                  Username
-                </label>
-                <div className="relative">
-                  <User className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
-                  <input
-                    type="text"
-                    value={editData.username}
-                    onChange={(e) => setEditData({ ...editData, username: e.target.value })}
-                    className="w-full pl-10 pr-4 py-3 bg-gray-700 border border-gray-600 text-white rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all duration-200 placeholder-gray-400"
-                    placeholder="Enter username"
-                    maxLength={30}
-                  />
-                </div>
-              </div>
-
-              {/* Bio */}
-              <div>
-                <label className="block text-sm font-medium text-gray-200 mb-2">
-                  Bio
-                </label>
-                <textarea
-                  value={editData.bio}
-                  onChange={(e) => setEditData({ ...editData, bio: e.target.value })}
-                  className="w-full px-4 py-3 bg-gray-700 border border-gray-600 text-white rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all duration-200 placeholder-gray-400 resize-none"
-                  placeholder="Tell us about yourself..."
-                  rows={2}
-                  maxLength={200}
-                />
-                <p className="text-xs text-gray-400 mt-1">{editData.bio.length}/200 characters</p>
-              </div>
-
-              {/* Avatar Color */}
-              <div>
-                <label className="block text-sm font-medium text-gray-200 mb-2">
-                  <Palette className="inline w-4 h-4 mr-1" />
-                  Avatar Color
-                </label>
-                <div className="grid grid-cols-4 sm:grid-cols-6 gap-2 sm:gap-3">
-                  {avatarColors.map((color) => (
-                    <button
-                      key={color}
-                      onClick={() => setEditData({ ...editData, avatar_color: color })}
-                      className={`w-10 h-10 sm:w-12 sm:h-12 rounded-full border-2 transition-all ${
-                        editData.avatar_color === color 
-                          ? 'border-white scale-110' 
-                          : 'border-gray-600 hover:border-gray-400'
-                      }`}
-                      style={{ backgroundColor: color }}
-                    />
-                  ))}
-                </div>
-              </div>
-
-              {/* Error/Success Messages */}
-              {error && (
-                <div className="bg-red-900/50 border border-red-700 text-red-200 px-4 py-3 rounded-lg text-sm">
-                  {error}
-                </div>
-              )}
-
-              {success && (
-                <div className="bg-green-900/50 border border-green-700 text-green-200 px-4 py-3 rounded-lg text-sm">
-                  Profile updated successfully!
-                </div>
-              )}
-
-              {/* Modal Actions */}
-              <div className="flex flex-col sm:flex-row gap-3 pt-4">
-                <button
-                  onClick={() => setShowEditModal(false)}
-                  className="flex-1 px-4 py-3 bg-gray-700 text-white rounded-lg hover:bg-gray-600 transition-colors order-2 sm:order-1"
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleSave}
-                  disabled={saving}
-                  className="flex-1 bg-gradient-to-r from-blue-600 to-purple-600 text-white py-3 px-6 rounded-lg font-medium hover:from-blue-700 hover:to-purple-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-800 transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98] shadow-lg disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none order-1 sm:order-2"
-                >
-                  {saving ? (
-                    <div className="flex items-center justify-center">
-                      <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></div>
-                      Saving...
-                    </div>
-                  ) : (
-                    <div className="flex items-center justify-center gap-2">
-                      <Save className="w-5 h-5" />
-                      Save Changes
-                    </div>
-                  )}
-                </button>
-              </div>
-            </div>
+              {/* Modal Content */}
+              <ProfileForm
+                user={user}
+                initialData={profileData}
+                onCancel={() => setShowEditModal(false)}
+                onSaved={(updated) => {
+                  setProfileData(updated);
+                  onUserUpdate({
+                    ...user,
+                    username: updated.username,
+                    avatar_color: updated.avatar_color
+                  });
+                }}
+              />
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- create `AvatarUpload` for shared avatar and banner upload logic
- create `ProfileForm` for profile edit form
- simplify `UserProfile` to use these components

## Testing
- `npx eslint .`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a155f902c8327b46e9f663b233e9e