### PR TITLE
Improve avatar loading with local cache

### DIFF
--- a/src/components/AvatarImage.tsx
+++ b/src/components/AvatarImage.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useCachedImage } from '../hooks/useCachedImage';
+
+interface AvatarImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  src: string | null | undefined;
+  fallbackColor?: string;
+  fallbackText?: string;
+}
+
+/**
+ * Displays an avatar image using a client side cache. If no src is provided
+ * a colored fallback circle with the supplied text is shown.
+ */
+export function AvatarImage({
+  src,
+  fallbackColor = '#666',
+  fallbackText = '?',
+  ...imgProps
+}: AvatarImageProps) {
+  const cachedSrc = useCachedImage(src);
+
+  if (!cachedSrc) {
+    return (
+      <div
+        style={{ backgroundColor: fallbackColor }}
+        className="w-full h-full flex items-center justify-center text-white text-sm font-bold"
+      >
+        {fallbackText}
+      </div>
+    );
+  }
+
+  return <img src={cachedSrc} {...imgProps} />;
+}

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { LogOut, UserCircle, Users, MessageCircle, Menu, X } from 'lucide-react';
+import { AvatarImage } from './AvatarImage';
 
 type PageType = 'group-chat' | 'dms' | 'profile';
 
@@ -134,13 +135,13 @@ export function ChatHeader({ userName, onClearUser, onShowProfile, currentPage, 
           <div className="hidden md:flex absolute inset-0 pointer-events-none items-center justify-center gap-2">
             {activeUsers.map((u) => (
               <div key={u.id} className="w-8 h-8 rounded-full overflow-hidden ring-2 ring-gray-700">
-                {u.avatar_url ? (
-                  <img src={u.avatar_url} alt={u.username} className="w-full h-full object-cover" />
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center text-xs font-medium text-white" style={{ backgroundColor: u.avatar_color }}>
-                    {u.username.charAt(0).toUpperCase()}
-                  </div>
-                )}
+                <AvatarImage
+                  src={u.avatar_url}
+                  alt={u.username}
+                  className="w-full h-full object-cover"
+                  fallbackColor={u.avatar_color}
+                  fallbackText={u.username.charAt(0).toUpperCase()}
+                />
               </div>
             ))}
           </div>

--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { MessageSquare, Send, X, ArrowLeft } from 'lucide-react';
+import { AvatarImage } from './AvatarImage';
 import { ContactSidebar } from './dms/ContactSidebar';
 import { DMMessageItem } from './dms/DMMessageItem';
 import { useDirectMessages } from '../hooks/useDirectMessages';
@@ -520,21 +521,14 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                     return (
                       <>
                           <div className="relative w-10 h-10 ring-2 ring-blue-400/30 rounded-full">
-                            <div className="w-full h-full rounded-full overflow-hidden">
-                              {otherUserData.avatar_url ? (
-                                <img
-                                  src={otherUserData.avatar_url}
-                                  alt={otherUserData.username}
-                                  className="w-full h-full object-cover"
-                                />
-                              ) : (
-                                <div
-                                  className="w-full h-full flex items-center justify-center text-white text-sm font-bold"
-                                  style={{ backgroundColor: otherUserData.avatar_color }}
-                                >
-                                  {otherUserData.username.charAt(0).toUpperCase()}
-                                </div>
-                              )}
+                          <div className="w-full h-full rounded-full overflow-hidden">
+                              <AvatarImage
+                                src={otherUserData.avatar_url}
+                                alt={otherUserData.username}
+                                className="w-full h-full object-cover"
+                                fallbackColor={otherUserData.avatar_color}
+                                fallbackText={otherUserData.username.charAt(0).toUpperCase()}
+                              />
                             </div>
                             {activeUserIds.includes(otherUserData.id) && (
                               <span className="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900 z-10" />

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Smile } from 'lucide-react';
+import { AvatarImage } from './AvatarImage';
 import { Message } from '../types/message';
 import { supabase } from '../lib/supabase';
 import { useToast } from './Toast';
@@ -82,30 +83,13 @@ export function MessageBubble({
         title={`View ${message.user_name}'s profile`}
       >
         <div className="w-full h-full rounded-full overflow-hidden">
-          {message.avatar_url ? (
-            <img
-              src={message.avatar_url}
-              alt={message.user_name}
-              className="w-full h-full rounded-full object-cover"
-              onError={(e) => {
-                e.currentTarget.style.display = 'none';
-                const parent = e.currentTarget.parentElement;
-                if (parent) {
-                  const fallback = parent.querySelector('.avatar-fallback') as HTMLElement;
-                  if (fallback) {
-                    fallback.style.display = 'flex';
-                  }
-                }
-              }}
-            />
-          ) : (
-            message.user_name.charAt(0).toUpperCase()
-          )}
-          {message.avatar_url && (
-            <span className="avatar-fallback absolute inset-0 flex items-center justify-center text-white text-xs sm:text-sm font-medium" style={{ display: 'none' }}>
-              {message.user_name.charAt(0).toUpperCase()}
-            </span>
-          )}
+          <AvatarImage
+            src={message.avatar_url || undefined}
+            alt={message.user_name}
+            className="w-full h-full rounded-full object-cover"
+            fallbackColor={message.avatar_color}
+            fallbackText={message.user_name.charAt(0).toUpperCase()}
+          />
         </div>
         {isActive && (
           <span className="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900 z-10" />

--- a/src/components/ProfilePreviewModal.tsx
+++ b/src/components/ProfilePreviewModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { X, Mail, Calendar } from 'lucide-react';
 import { supabase } from '../lib/supabase';
+import { AvatarImage } from './AvatarImage';
 
 interface ProfilePreviewModalProps {
   userId: string;
@@ -112,20 +113,13 @@ export function ProfilePreviewModal({ userId, onClose }: ProfilePreviewModalProp
               {/* Avatar & Basic Info */}
               <div className="flex items-end space-x-4">
                 <div className="-mt-8 sm:-mt-12 w-16 h-16 sm:w-20 sm:h-20 rounded-full overflow-hidden bg-gray-600 ring-4 ring-gray-800 flex-shrink-0">
-                  {profile.avatar_url ? (
-                    <img
-                      src={profile.avatar_url}
-                      alt="Avatar"
-                      className="w-full h-full object-cover"
-                    />
-                  ) : (
-                    <div 
-                      className="w-full h-full flex items-center justify-center text-white text-lg sm:text-xl font-bold"
-                      style={{ backgroundColor: profile.avatar_color }}
-                    >
-                      {profile.username.charAt(0).toUpperCase()}
-                    </div>
-                  )}
+                  <AvatarImage
+                    src={profile.avatar_url}
+                    alt="Avatar"
+                    className="w-full h-full object-cover"
+                    fallbackColor={profile.avatar_color}
+                    fallbackText={profile.username.charAt(0).toUpperCase()}
+                  />
                 </div>
                 <div className="flex-1">
                   <h2 className="text-lg sm:text-xl font-bold text-white">{profile.username}</h2>

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -3,6 +3,7 @@ import { X, User, Mail, Palette, Save, Upload, ArrowLeft } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { ChatHeader } from './ChatHeader';
 import { avatarColors } from '../utils/avatarColors';
+import { AvatarImage } from './AvatarImage';
 
 type PageType = 'group-chat' | 'dms' | 'profile';
 
@@ -271,20 +272,13 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
             <div className="px-4 sm:px-6 pt-0 pb-4 sm:pb-6 relative space-y-3 sm:space-y-4 flex-1">
               <div className="flex items-end space-x-4">
                 <div className="-mt-8 sm:-mt-12 w-16 h-16 sm:w-24 sm:h-24 rounded-full overflow-hidden bg-gray-600 ring-4 ring-gray-800 flex-shrink-0">
-                  {profileData.avatar_url ? (
-                    <img
-                      src={profileData.avatar_url}
-                      alt="Avatar"
-                      className="w-full h-full object-cover"
-                    />
-                  ) : (
-                    <div 
-                      className="w-full h-full flex items-center justify-center text-white text-lg sm:text-2xl font-bold"
-                      style={{ backgroundColor: profileData.avatar_color }}
-                    >
-                      {profileData.username.charAt(0).toUpperCase()}
-                    </div>
-                  )}
+                  <AvatarImage
+                    src={profileData.avatar_url}
+                    alt="Avatar"
+                    className="w-full h-full object-cover"
+                    fallbackColor={profileData.avatar_color}
+                    fallbackText={profileData.username.charAt(0).toUpperCase()}
+                  />
                 </div>
                 <div className="flex-1">
                   <h2 className="text-lg sm:text-xl font-bold text-white">{profileData.username}</h2>
@@ -407,20 +401,13 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
                       style={editData.avatar_url ? { border: 'none' } : {}}
                       onClick={() => document.getElementById('avatar-upload')?.click()}
                     >
-                      {editData.avatar_url ? (
-                        <img
-                          src={editData.avatar_url}
-                          alt="Avatar preview"
-                          className="w-full h-full object-cover"
-                        />
-                      ) : (
-                        <div 
-                          className="w-full h-full flex items-center justify-center text-white text-lg sm:text-xl font-bold"
-                          style={{ backgroundColor: editData.avatar_color }}
-                        >
-                          {editData.username.charAt(0).toUpperCase()}
-                        </div>
-                      )}
+                      <AvatarImage
+                        src={editData.avatar_url}
+                        alt="Avatar preview"
+                        className="w-full h-full object-cover"
+                        fallbackColor={editData.avatar_color}
+                        fallbackText={editData.username.charAt(0).toUpperCase()}
+                      />
                       {uploadingAvatar && (
                         <div className="absolute inset-0 bg-black/50 flex items-center justify-center rounded-full">
                           <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-white"></div>

--- a/src/components/dms/ContactSidebar.tsx
+++ b/src/components/dms/ContactSidebar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Search, MessageSquare, Clock, Users, ArrowLeft } from 'lucide-react';
+import { AvatarImage } from '../AvatarImage';
 
 interface User {
   id: string;
@@ -149,13 +150,13 @@ export function ContactSidebar({
                           <div className="flex items-center gap-3">
                             <div className="relative w-10 h-10 flex-shrink-0 ring-2 ring-gray-600/30 rounded-full">
                               <div className="w-full h-full rounded-full overflow-hidden">
-                                {otherUserData.avatar_url ? (
-                                  <img src={otherUserData.avatar_url} alt={otherUserData.username} className="w-full h-full object-cover" />
-                                ) : (
-                                  <div className="w-full h-full flex items-center justify-center text-white text-sm font-bold" style={{ backgroundColor: otherUserData.avatar_color }}>
-                                    {otherUserData.username.charAt(0).toUpperCase()}
-                                  </div>
-                                )}
+                                <AvatarImage
+                                  src={otherUserData.avatar_url}
+                                  alt={otherUserData.username}
+                                  className="w-full h-full object-cover"
+                                  fallbackColor={otherUserData.avatar_color}
+                                  fallbackText={otherUserData.username.charAt(0).toUpperCase()}
+                                />
                               </div>
                               {activeUserIds.includes(otherUserData.id) && <span className="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900 z-10" />}
                             </div>
@@ -195,13 +196,13 @@ export function ContactSidebar({
                         <div className="flex items-center gap-3">
                           <div className="relative w-10 h-10 flex-shrink-0 ring-2 ring-gray-600/30 rounded-full">
                             <div className="w-full h-full rounded-full overflow-hidden">
-                              {user.avatar_url ? (
-                                <img src={user.avatar_url} alt={user.username} className="w-full h-full object-cover" />
-                              ) : (
-                                <div className="w-full h-full flex items-center justify-center text-white text-sm font-bold" style={{ backgroundColor: user.avatar_color }}>
-                                  {user.username.charAt(0).toUpperCase()}
-                                </div>
-                              )}
+                              <AvatarImage
+                                src={user.avatar_url}
+                                alt={user.username}
+                                className="w-full h-full object-cover"
+                                fallbackColor={user.avatar_color}
+                                fallbackText={user.username.charAt(0).toUpperCase()}
+                              />
                             </div>
                             {activeUserIds.includes(user.id) && <span className="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900 z-10" />}
                           </div>

--- a/src/components/dms/DMMessageItem.tsx
+++ b/src/components/dms/DMMessageItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Smile } from 'lucide-react';
+import { AvatarImage } from '../AvatarImage';
 
 interface User {
   id: string;
@@ -71,19 +72,21 @@ export function DMMessageItem({
       >
         <div className="w-full h-full rounded-full overflow-hidden">
           {isOwn ? (
-            currentUserData?.avatar_url ? (
-              <img src={currentUserData.avatar_url} alt={currentUser.username} className="w-full h-full object-cover" />
-            ) : (
-              <div className="w-full h-full flex items-center justify-center text-white text-sm font-bold" style={{ backgroundColor: currentUserData?.avatar_color || currentUser.avatar_color }}>
-                {currentUser.username.charAt(0).toUpperCase()}
-              </div>
-            )
-          ) : otherUserData.avatar_url ? (
-            <img src={otherUserData.avatar_url} alt={otherUserData.username} className="w-full h-full object-cover" />
+            <AvatarImage
+              src={currentUserData?.avatar_url}
+              alt={currentUser.username}
+              className="w-full h-full object-cover"
+              fallbackColor={currentUserData?.avatar_color || currentUser.avatar_color}
+              fallbackText={currentUser.username.charAt(0).toUpperCase()}
+            />
           ) : (
-            <div className="w-full h-full flex items-center justify-center text-white text-sm font-bold" style={{ backgroundColor: otherUserData.avatar_color }}>
-              {otherUserData.username.charAt(0).toUpperCase()}
-            </div>
+            <AvatarImage
+              src={otherUserData.avatar_url}
+              alt={otherUserData.username}
+              className="w-full h-full object-cover"
+              fallbackColor={otherUserData.avatar_color}
+              fallbackText={otherUserData.username.charAt(0).toUpperCase()}
+            />
           )}
         </div>
         {activeUserIds.includes(message.sender_id) &&

--- a/src/hooks/useCachedImage.ts
+++ b/src/hooks/useCachedImage.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns a cached data URL for the given image URL. If no cached
+ * version exists in localStorage, the image is fetched, cached and
+ * then returned. When the URL changes the hook will fetch again.
+ */
+export function useCachedImage(url: string | null | undefined): string | null {
+  const [cached, setCached] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!url) {
+      setCached(null);
+      return;
+    }
+    const key = `avatar:${url}`;
+    const cachedValue = localStorage.getItem(key);
+    if (cachedValue) {
+      setCached(cachedValue);
+      return;
+    }
+
+    let cancelled = false;
+    fetch(url)
+      .then((res) => res.blob())
+      .then((blob) => {
+        if (cancelled) return;
+        const reader = new FileReader();
+        reader.onloadend = () => {
+          const dataUrl = reader.result as string;
+          try {
+            localStorage.setItem(key, dataUrl);
+          } catch {
+            // ignore quota errors
+          }
+          setCached(dataUrl);
+        };
+        reader.readAsDataURL(blob);
+      })
+      .catch(() => {
+        if (!cancelled) setCached(url);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  return cached || url || null;
+}


### PR DESCRIPTION
## Summary
- add hook `useCachedImage` to store avatar images in localStorage
- create `AvatarImage` component utilizing the cache
- use `AvatarImage` across profile and DM components

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a17b172d0832785eaeba265bf78d2