### PR TITLE
Refactor profile editing components

### DIFF
--- a/src/__tests__/ProfileForm.test.tsx
+++ b/src/__tests__/ProfileForm.test.tsx
@@ -1,15 +1,34 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { ProfileForm } from '../components/ProfileForm';
+import { ProfileForm, ProfileFormValues } from '../components/ProfileForm';
 import '@testing-library/jest-dom';
 
-test('submits updated values', () => {
-  const handleSubmit = jest.fn();
-  render(<ProfileForm initialValues={{ username: 'john', bio: 'hello' }} onSubmit={handleSubmit} />);
+test('calls onSave with updated values', () => {
+  const handleSave = jest.fn();
+  function Wrapper() {
+    const [values, setValues] = useState<ProfileFormValues>({
+      username: 'john',
+      bio: 'hello',
+      avatar_color: '#000',
+      avatar_url: '',
+      banner_url: ''
+    });
+    return (
+      <ProfileForm
+        values={values}
+        onChange={setValues}
+        onCancel={() => {}}
+        onSave={() => handleSave(values)}
+        saving={false}
+      />
+    );
+  }
+
+  render(<Wrapper />);
 
   fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'jane' } });
   fireEvent.change(screen.getByLabelText(/bio/i), { target: { value: 'hi' } });
-  fireEvent.click(screen.getByText(/save/i));
+  fireEvent.click(screen.getByText(/save changes/i));
 
-  expect(handleSubmit).toHaveBeenCalledWith({ username: 'jane', bio: 'hi' });
+  expect(handleSave).toHaveBeenCalledWith(expect.objectContaining({ username: 'jane', bio: 'hi' }));
 });

--- a/src/components/AvatarUpload.tsx
+++ b/src/components/AvatarUpload.tsx
@@ -1,0 +1,116 @@
+import React, { useState } from 'react';
+import { Upload, X } from 'lucide-react';
+
+interface AvatarUploadProps {
+  type: 'avatar' | 'banner';
+  url: string;
+  username?: string;
+  avatarColor?: string;
+  onChange: (url: string) => void;
+}
+
+export function AvatarUpload({ type, url, username = '', avatarColor = '#3B82F6', onChange }: AvatarUploadProps) {
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const uploadImage = async (file: File): Promise<string> => {
+    const { supabase } = await import('../lib/supabase');
+    const fileExt = file.name.split('.').pop();
+    const fileName = `${Date.now()}-${Math.random().toString(36).slice(2)}.${fileExt}`;
+
+    const { error } = await supabase.storage
+      .from('images')
+      .upload(fileName, file, {
+        cacheControl: '3600',
+        upsert: false,
+      });
+
+    if (error) throw error;
+
+    const { data: { publicUrl } } = supabase.storage
+      .from('images')
+      .getPublicUrl(fileName);
+
+    return publicUrl;
+  };
+
+  const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (!file.type.startsWith('image/')) {
+      setError('Please select a valid image');
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      setError('Image size must be less than 5MB');
+      return;
+    }
+
+    try {
+      setUploading(true);
+      setError(null);
+      const imageUrl = await uploadImage(file);
+      onChange(imageUrl);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to upload image');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <div
+        className={
+          type === 'avatar'
+            ? 'w-20 h-20 sm:w-24 sm:h-24 rounded-full overflow-hidden cursor-pointer hover:opacity-80 transition-opacity border-2 border-dashed border-gray-600 hover:border-gray-400 flex items-center justify-center'
+            : 'w-full h-24 sm:h-32 bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg overflow-hidden cursor-pointer hover:opacity-80 transition-opacity border-2 border-dashed border-gray-600 hover:border-gray-400'
+        }
+        style={url ? { backgroundImage: `url(${url})`, backgroundSize: 'cover', backgroundPosition: 'center', border: 'none' } : {}}
+        onClick={() => document.getElementById(`${type}-upload-input`)?.click()}
+      >
+        {!url && (
+          type === 'avatar' ? (
+            <div className="w-full h-full flex items-center justify-center text-white text-lg sm:text-xl font-bold" style={{ backgroundColor: avatarColor }}>
+              {username.charAt(0).toUpperCase()}
+            </div>
+          ) : (
+            <div className="flex items-center justify-center h-full text-white text-center">
+              <div>
+                <Upload className="w-6 h-6 sm:w-8 sm:h-8 mx-auto mb-2" />
+                <p className="text-xs sm:text-sm">Click to upload {type}</p>
+              </div>
+            </div>
+          )
+        )}
+        {uploading && (
+          <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
+            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-white" />
+          </div>
+        )}
+      </div>
+      <input
+        id={`${type}-upload-input`}
+        type="file"
+        accept="image/*"
+        onChange={handleChange}
+        className="hidden"
+      />
+      {url && !uploading && (
+        <button
+          type="button"
+          onClick={() => onChange('')}
+          className={
+            type === 'avatar'
+              ? 'absolute -top-1 -right-1 p-1 bg-red-600 hover:bg-red-700 text-white rounded-full transition-colors'
+              : 'absolute top-2 right-2 p-1 bg-red-600 hover:bg-red-700 text-white rounded-full transition-colors'
+          }
+        >
+          <X className="w-3 h-3" />
+        </button>
+      )}
+      {error && <p className="text-red-400 text-xs mt-1">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -1,33 +1,141 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { User, Palette, Save } from 'lucide-react';
+import { avatarColors } from '../utils/avatarColors';
+import { AvatarUpload } from './AvatarUpload';
 
-interface ProfileFormProps {
-  initialValues: { username: string; bio?: string };
-  onSubmit: (values: { username: string; bio: string }) => void;
+export interface ProfileFormValues {
+  username: string;
+  bio: string;
+  avatar_color: string;
+  avatar_url: string;
+  banner_url: string;
 }
 
-export function ProfileForm({ initialValues, onSubmit }: ProfileFormProps) {
-  const [username, setUsername] = useState(initialValues.username);
-  const [bio, setBio] = useState(initialValues.bio || '');
+interface ProfileFormProps {
+  values: ProfileFormValues;
+  onChange: (v: ProfileFormValues) => void;
+  onCancel: () => void;
+  onSave: () => void;
+  saving: boolean;
+  error?: string | null;
+  success?: boolean;
+}
 
+export function ProfileForm({ values, onChange, onCancel, onSave, saving, error, success }: ProfileFormProps) {
   return (
-    <form onSubmit={e => { e.preventDefault(); onSubmit({ username, bio }); }}>
-      <label>
-        Username
-        <input
-          aria-label="username"
-          value={username}
-          onChange={e => setUsername(e.target.value)}
+    <div className="p-4 sm:p-6 space-y-4 sm:space-y-6">
+      <div>
+        <label className="block text-sm font-medium text-gray-200 mb-2">Banner Image</label>
+        <AvatarUpload
+          type="banner"
+          url={values.banner_url}
+          username={values.username}
+          avatarColor={values.avatar_color}
+          onChange={(url) => onChange({ ...values, banner_url: url })}
         />
-      </label>
-      <label>
-        Bio
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-200 mb-2">Profile Picture</label>
+        <div className="flex flex-col sm:flex-row items-center gap-4">
+          <AvatarUpload
+            type="avatar"
+            url={values.avatar_url}
+            username={values.username}
+            avatarColor={values.avatar_color}
+            onChange={(url) => onChange({ ...values, avatar_url: url })}
+          />
+          <div className="flex-1">
+            <p className="text-xs sm:text-sm text-gray-300 mb-2 text-center sm:text-left">Click the avatar to upload a custom image</p>
+            <p className="text-xs text-gray-400 text-center sm:text-left">Recommended: Square image, max 5MB</p>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-200 mb-2">Username</label>
+        <div className="relative">
+          <User className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
+          <input
+            type="text"
+            aria-label="username"
+            value={values.username}
+            onChange={(e) => onChange({ ...values, username: e.target.value })}
+            className="w-full pl-10 pr-4 py-3 bg-gray-700 border border-gray-600 text-white rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all duration-200 placeholder-gray-400"
+            placeholder="Enter username"
+            maxLength={30}
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-200 mb-2">Bio</label>
         <textarea
           aria-label="bio"
-          value={bio}
-          onChange={e => setBio(e.target.value)}
+          value={values.bio}
+          onChange={(e) => onChange({ ...values, bio: e.target.value })}
+          className="w-full px-4 py-3 bg-gray-700 border border-gray-600 text-white rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all duration-200 placeholder-gray-400 resize-none"
+          placeholder="Tell us about yourself..."
+          rows={2}
+          maxLength={200}
         />
-      </label>
-      <button type="submit">Save</button>
-    </form>
+        <p className="text-xs text-gray-400 mt-1">{values.bio.length}/200 characters</p>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-200 mb-2">
+          <Palette className="inline w-4 h-4 mr-1" /> Avatar Color
+        </label>
+        <div className="grid grid-cols-4 sm:grid-cols-6 gap-2 sm:gap-3">
+          {avatarColors.map((color) => (
+            <button
+              key={color}
+              type="button"
+              onClick={() => onChange({ ...values, avatar_color: color })}
+              className={`w-10 h-10 sm:w-12 sm:h-12 rounded-full border-2 transition-all ${
+                values.avatar_color === color ? 'border-white scale-110' : 'border-gray-600 hover:border-gray-400'
+              }`}
+              style={{ backgroundColor: color }}
+            />
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-red-900/50 border border-red-700 text-red-200 px-4 py-3 rounded-lg text-sm">{error}</div>
+      )}
+
+      {success && (
+        <div className="bg-green-900/50 border border-green-700 text-green-200 px-4 py-3 rounded-lg text-sm">Profile updated successfully!</div>
+      )}
+
+      <div className="flex flex-col sm:flex-row gap-3 pt-4">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="flex-1 px-4 py-3 bg-gray-700 text-white rounded-lg hover:bg-gray-600 transition-colors order-2 sm:order-1"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={saving}
+          className="flex-1 bg-gradient-to-r from-blue-600 to-purple-600 text-white py-3 px-6 rounded-lg font-medium hover:from-blue-700 hover:to-purple-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-800 transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98] shadow-lg disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none order-1 sm:order-2"
+        >
+          {saving ? (
+            <div className="flex items-center justify-center">
+              <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></div>
+              Saving...
+            </div>
+          ) : (
+            <div className="flex items-center justify-center gap-2">
+              <Save className="w-5 h-5" />
+              Save Changes
+            </div>
+          )}
+        </button>
+      </div>
+    </div>
   );
 }

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { X, User, Mail, Palette, Save, Upload, ArrowLeft } from 'lucide-react';
+import { X, Mail, ArrowLeft } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { ChatHeader } from './ChatHeader';
-import { avatarColors } from '../utils/avatarColors';
+import { ProfileForm, ProfileFormValues } from './ProfileForm';
 
 type PageType = 'group-chat' | 'dms' | 'profile';
 
@@ -30,7 +30,7 @@ interface UserProfileProps {
 
 
 export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageChange }: UserProfileProps) {
-  const [profileData, setProfileData] = useState({
+  const [profileData, setProfileData] = useState<ProfileFormValues & { created_at: string }>({
     username: user.username,
     bio: '',
     avatar_color: user.avatar_color,
@@ -42,7 +42,7 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
   const [showEditModal, setShowEditModal] = useState(false);
 
   // Edit modal state
-  const [editData, setEditData] = useState({
+  const [editData, setEditData] = useState<ProfileFormValues>({
     username: user.username,
     bio: '',
     avatar_color: user.avatar_color,
@@ -52,8 +52,6 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
-  const [uploadingAvatar, setUploadingAvatar] = useState(false);
-  const [uploadingBanner, setUploadingBanner] = useState(false);
 
   useEffect(() => {
     fetchUserProfile();
@@ -151,65 +149,6 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
     }
   };
 
-  const uploadImage = async (file: File, type: 'avatar' | 'banner'): Promise<string> => {
-    const fileExt = file.name.split('.').pop();
-    const fileName = `${user.id}/${type}_${Date.now()}.${fileExt}`;
-    
-    const { error } = await supabase.storage
-      .from('images')
-      .upload(fileName, file, {
-        cacheControl: '3600',
-        upsert: false
-      });
-
-    if (error) throw error;
-
-    const { data: { publicUrl } } = supabase.storage
-      .from('images')
-      .getPublicUrl(fileName);
-
-    return publicUrl;
-  };
-
-  const handleImageUpload = async (file: File, type: 'avatar' | 'banner') => {
-    if (!file) return;
-
-    // Validate file type
-    if (!file.type.startsWith('image/')) {
-      setError('Please select a valid image file');
-      return;
-    }
-
-    // Validate file size (max 5MB)
-    if (file.size > 5 * 1024 * 1024) {
-      setError('Image size must be less than 5MB');
-      return;
-    }
-
-    try {
-      if (type === 'avatar') {
-        setUploadingAvatar(true);
-      } else {
-        setUploadingBanner(true);
-      }
-      
-      setError(null);
-      const imageUrl = await uploadImage(file, type);
-      
-      setEditData({
-        ...editData,
-        [type === 'avatar' ? 'avatar_url' : 'banner_url']: imageUrl
-      });
-    } catch (err) {
-      setError(err instanceof Error ? err.message : `Failed to upload ${type}`);
-    } finally {
-      if (type === 'avatar') {
-        setUploadingAvatar(false);
-      } else {
-        setUploadingBanner(false);
-      }
-    }
-  };
 
   const formatJoinDate = (dateString: string) => {
     if (!dateString) return 'Unknown';
@@ -343,212 +282,15 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
             </div>
 
             {/* Modal Content */}
-            <div className="p-4 sm:p-6 space-y-4 sm:space-y-6">
-              {/* Banner Preview & Upload */}
-              <div>
-                <label className="block text-sm font-medium text-gray-200 mb-2">
-                  Banner Image
-                </label>
-                <div className="relative">
-                  <div 
-                    className="w-full h-24 sm:h-32 bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg overflow-hidden cursor-pointer hover:opacity-80 transition-opacity border-2 border-dashed border-gray-600 hover:border-gray-400"
-                    style={editData.banner_url ? { 
-                      backgroundImage: `url(${editData.banner_url})`,
-                      backgroundSize: 'cover',
-                      backgroundPosition: 'center',
-                      border: 'none'
-                    } : {}}
-                    onClick={() => document.getElementById('banner-upload')?.click()}
-                  >
-                    {!editData.banner_url && (
-                      <div className="flex items-center justify-center h-full">
-                        <div className="text-center text-white">
-                          <Upload className="w-6 h-6 sm:w-8 sm:h-8 mx-auto mb-2" />
-                          <p className="text-xs sm:text-sm">Click to upload banner</p>
-                        </div>
-                      </div>
-                    )}
-                    {uploadingBanner && (
-                      <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
-                        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
-                      </div>
-                    )}
-                  </div>
-                  <input
-                    id="banner-upload"
-                    type="file"
-                    accept="image/*"
-                    onChange={(e) => {
-                      const file = e.target.files?.[0];
-                      if (file) handleImageUpload(file, 'banner');
-                    }}
-                    className="hidden"
-                  />
-                  {editData.banner_url && (
-                    <button
-                      onClick={() => setEditData({ ...editData, banner_url: '' })}
-                      className="absolute top-2 right-2 p-1 bg-red-600 hover:bg-red-700 text-white rounded-full transition-colors"
-                    >
-                      <X className="w-4 h-4" />
-                    </button>
-                  )}
-                </div>
-              </div>
-
-              {/* Avatar Preview & Upload */}
-              <div>
-                <label className="block text-sm font-medium text-gray-200 mb-2">
-                  Profile Picture
-                </label>
-                <div className="flex flex-col sm:flex-row items-center gap-4">
-                  <div className="relative">
-                    <div 
-                      className="w-20 h-20 sm:w-24 sm:h-24 rounded-full overflow-hidden cursor-pointer hover:opacity-80 transition-opacity border-2 border-dashed border-gray-600 hover:border-gray-400 flex items-center justify-center"
-                      style={editData.avatar_url ? { border: 'none' } : {}}
-                      onClick={() => document.getElementById('avatar-upload')?.click()}
-                    >
-                      {editData.avatar_url ? (
-                        <img
-                          src={editData.avatar_url}
-                          alt="Avatar preview"
-                          className="w-full h-full object-cover"
-                        />
-                      ) : (
-                        <div 
-                          className="w-full h-full flex items-center justify-center text-white text-lg sm:text-xl font-bold"
-                          style={{ backgroundColor: editData.avatar_color }}
-                        >
-                          {editData.username.charAt(0).toUpperCase()}
-                        </div>
-                      )}
-                      {uploadingAvatar && (
-                        <div className="absolute inset-0 bg-black/50 flex items-center justify-center rounded-full">
-                          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-white"></div>
-                        </div>
-                      )}
-                    </div>
-                    <input
-                      id="avatar-upload"
-                      type="file"
-                      accept="image/*"
-                      onChange={(e) => {
-                        const file = e.target.files?.[0];
-                        if (file) handleImageUpload(file, 'avatar');
-                      }}
-                      className="hidden"
-                    />
-                    {editData.avatar_url && (
-                      <button
-                        onClick={() => setEditData({ ...editData, avatar_url: '' })}
-                        className="absolute -top-1 -right-1 p-1 bg-red-600 hover:bg-red-700 text-white rounded-full transition-colors"
-                      >
-                        <X className="w-3 h-3" />
-                      </button>
-                    )}
-                  </div>
-                  <div className="flex-1">
-                    <p className="text-xs sm:text-sm text-gray-300 mb-2 text-center sm:text-left">Click the avatar to upload a custom image</p>
-                    <p className="text-xs text-gray-400 text-center sm:text-left">Recommended: Square image, max 5MB</p>
-                  </div>
-                </div>
-              </div>
-
-              {/* Username */}
-              <div>
-                <label className="block text-sm font-medium text-gray-200 mb-2">
-                  Username
-                </label>
-                <div className="relative">
-                  <User className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
-                  <input
-                    type="text"
-                    value={editData.username}
-                    onChange={(e) => setEditData({ ...editData, username: e.target.value })}
-                    className="w-full pl-10 pr-4 py-3 bg-gray-700 border border-gray-600 text-white rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all duration-200 placeholder-gray-400"
-                    placeholder="Enter username"
-                    maxLength={30}
-                  />
-                </div>
-              </div>
-
-              {/* Bio */}
-              <div>
-                <label className="block text-sm font-medium text-gray-200 mb-2">
-                  Bio
-                </label>
-                <textarea
-                  value={editData.bio}
-                  onChange={(e) => setEditData({ ...editData, bio: e.target.value })}
-                  className="w-full px-4 py-3 bg-gray-700 border border-gray-600 text-white rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all duration-200 placeholder-gray-400 resize-none"
-                  placeholder="Tell us about yourself..."
-                  rows={2}
-                  maxLength={200}
-                />
-                <p className="text-xs text-gray-400 mt-1">{editData.bio.length}/200 characters</p>
-              </div>
-
-              {/* Avatar Color */}
-              <div>
-                <label className="block text-sm font-medium text-gray-200 mb-2">
-                  <Palette className="inline w-4 h-4 mr-1" />
-                  Avatar Color
-                </label>
-                <div className="grid grid-cols-4 sm:grid-cols-6 gap-2 sm:gap-3">
-                  {avatarColors.map((color) => (
-                    <button
-                      key={color}
-                      onClick={() => setEditData({ ...editData, avatar_color: color })}
-                      className={`w-10 h-10 sm:w-12 sm:h-12 rounded-full border-2 transition-all ${
-                        editData.avatar_color === color 
-                          ? 'border-white scale-110' 
-                          : 'border-gray-600 hover:border-gray-400'
-                      }`}
-                      style={{ backgroundColor: color }}
-                    />
-                  ))}
-                </div>
-              </div>
-
-              {/* Error/Success Messages */}
-              {error && (
-                <div className="bg-red-900/50 border border-red-700 text-red-200 px-4 py-3 rounded-lg text-sm">
-                  {error}
-                </div>
-              )}
-
-              {success && (
-                <div className="bg-green-900/50 border border-green-700 text-green-200 px-4 py-3 rounded-lg text-sm">
-                  Profile updated successfully!
-                </div>
-              )}
-
-              {/* Modal Actions */}
-              <div className="flex flex-col sm:flex-row gap-3 pt-4">
-                <button
-                  onClick={() => setShowEditModal(false)}
-                  className="flex-1 px-4 py-3 bg-gray-700 text-white rounded-lg hover:bg-gray-600 transition-colors order-2 sm:order-1"
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleSave}
-                  disabled={saving}
-                  className="flex-1 bg-gradient-to-r from-blue-600 to-purple-600 text-white py-3 px-6 rounded-lg font-medium hover:from-blue-700 hover:to-purple-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-800 transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98] shadow-lg disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none order-1 sm:order-2"
-                >
-                  {saving ? (
-                    <div className="flex items-center justify-center">
-                      <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></div>
-                      Saving...
-                    </div>
-                  ) : (
-                    <div className="flex items-center justify-center gap-2">
-                      <Save className="w-5 h-5" />
-                      Save Changes
-                    </div>
-                  )}
-                </button>
-              </div>
-            </div>
+            <ProfileForm
+              values={editData as ProfileFormValues}
+              onChange={(v) => setEditData(v)}
+              onCancel={() => setShowEditModal(false)}
+              onSave={handleSave}
+              saving={saving}
+              error={error}
+              success={success}
+            />
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- create `AvatarUpload` for handling image uploads
- move profile editing fields into `ProfileForm`
- refactor `UserProfile` to use new components
- update tests for new form behaviour

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685a179c356083278d7733d79aea600a