### PR TITLE
Refresh without reload on focus

### DIFF
--- a/src/__tests__/RootRefresh.test.tsx
+++ b/src/__tests__/RootRefresh.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+jest.mock('../App.tsx', () => ({ __esModule: true, default: () => <div /> }));
+jest.mock('../hooks/usePresence', () => ({ usePresence: () => [] }));
+
+let Root: React.FC;
+beforeEach(async () => {
+  document.body.innerHTML = '<div id="root"></div>';
+  const mod = await import('../main');
+  Root = mod.Root;
+});
+import * as auth from '../hooks/useAuth';
+import * as messages from '../hooks/useMessages';
+import * as presence from '../utils/updatePresence';
+
+import '@testing-library/jest-dom';
+
+jest.mock('../lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn().mockResolvedValue({ data: { session: null } }),
+      onAuthStateChange: jest.fn().mockReturnValue({ data: { subscription: { unsubscribe: jest.fn() } } }),
+      signOut: jest.fn(),
+    },
+    channel: jest.fn(() => ({ on: jest.fn().mockReturnThis(), subscribe: jest.fn(), unsubscribe: jest.fn() })),
+    from: jest.fn(() => ({ select: jest.fn().mockReturnThis(), order: jest.fn().mockReturnThis(), limit: jest.fn().mockReturnThis(), lt: jest.fn().mockReturnThis() })),
+    rpc: jest.fn(),
+  },
+}));
+
+test('focus triggers refresh without reload', () => {
+  const authSpy = jest.spyOn(auth, 'triggerAuthRefresh').mockImplementation(() => Promise.resolve());
+  const msgSpy = jest.spyOn(messages, 'triggerMessagesRefresh').mockImplementation(() => {});
+  const presSpy = jest.spyOn(presence, 'updatePresence').mockImplementation(() => Promise.resolve());
+
+  render(<Root />);
+
+  window.dispatchEvent(new Event('focus'));
+
+  expect(authSpy).toHaveBeenCalled();
+  expect(msgSpy).toHaveBeenCalled();
+  expect(presSpy).toHaveBeenCalled();
+});
+
+test('visibility change triggers refresh', () => {
+  const authSpy = jest.spyOn(auth, 'triggerAuthRefresh').mockImplementation(() => Promise.resolve());
+  const msgSpy = jest.spyOn(messages, 'triggerMessagesRefresh').mockImplementation(() => {});
+  const presSpy = jest.spyOn(presence, 'updatePresence').mockImplementation(() => Promise.resolve());
+
+  render(<Root />);
+
+  Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+  document.dispatchEvent(new Event('visibilitychange'));
+
+  expect(authSpy).toHaveBeenCalled();
+  expect(msgSpy).toHaveBeenCalled();
+  expect(presSpy).toHaveBeenCalled();
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,34 +3,30 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import { ToastProvider } from './components/Toast';
 import './index.css';
+import { triggerAuthRefresh } from './hooks/useAuth';
+import { triggerMessagesRefresh } from './hooks/useMessages';
+import { updatePresence } from './utils/updatePresence';
 
 // Component responsible for setting up focus/visibility event listeners.
-function Root() {
+export function Root() {
   useEffect(() => {
-    // Reload the entire page whenever the tab regains focus after being
-    // backgrounded. This helps recover when the app becomes flaky after a
-    // long period of inactivity.
-    let hasFocusedOnce = document.hasFocus();
-
-    const reloadOnFocus = () => {
-      if (hasFocusedOnce) {
-        window.location.reload();
-      } else {
-        hasFocusedOnce = true;
-      }
+    const handleRefresh = () => {
+      triggerAuthRefresh();
+      triggerMessagesRefresh();
+      updatePresence();
     };
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
-        reloadOnFocus();
+        handleRefresh();
       }
     };
 
-    window.addEventListener('focus', reloadOnFocus);
+    window.addEventListener('focus', handleRefresh);
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
-      window.removeEventListener('focus', reloadOnFocus);
+      window.removeEventListener('focus', handleRefresh);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, []);


### PR DESCRIPTION
## Summary
- refresh session, messages, and presence rather than reloading page
- expose refresh helpers from auth and messages hooks
- add tests for focus/visibility refresh behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a19b318e483279077c0967ed93dd9