### PR TITLE
Refactor profile forms

### DIFF
--- a/src/components/AvatarUpload.tsx
+++ b/src/components/AvatarUpload.tsx
@@ -1,0 +1,124 @@
+import React, { useState } from 'react';
+import { Upload, X } from 'lucide-react';
+import { AvatarImage } from './AvatarImage';
+
+interface AvatarUploadProps {
+  userId: string;
+  type: 'avatar' | 'banner';
+  imageUrl?: string;
+  avatarColor?: string;
+  username?: string;
+  onChange: (url: string) => void;
+}
+
+export function AvatarUpload({
+  userId,
+  type,
+  imageUrl = '',
+  avatarColor,
+  username,
+  onChange,
+}: AvatarUploadProps) {
+  const [uploading, setUploading] = useState(false);
+
+  const uploadImage = async (file: File): Promise<string> => {
+    const { supabase } = await import('../lib/supabase');
+    const fileExt = file.name.split('.').pop();
+    const fileName = `${userId}/${type}_${Date.now()}.${fileExt}`;
+    const { error } = await supabase.storage
+      .from('images')
+      .upload(fileName, file, { cacheControl: '3600', upsert: false });
+
+    if (error) throw error;
+
+    const { data: { publicUrl } } = supabase.storage
+      .from('images')
+      .getPublicUrl(fileName);
+
+    return publicUrl;
+  };
+
+  const handleFileChange = async (file: File) => {
+    if (!file) return;
+    if (!file.type.startsWith('image/')) return;
+    if (file.size > 5 * 1024 * 1024) return;
+
+    try {
+      setUploading(true);
+      const url = await uploadImage(file);
+      onChange(url);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const inputId = `${type}-upload`;
+
+  return (
+    <div className="relative">
+      {type === 'banner' ? (
+        <div
+          className="w-full h-24 sm:h-32 bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg overflow-hidden cursor-pointer hover:opacity-80 transition-opacity border-2 border-dashed border-gray-600 hover:border-gray-400"
+          style={imageUrl ? {
+            backgroundImage: `url(${imageUrl})`,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+            border: 'none'
+          } : {}}
+          onClick={() => document.getElementById(inputId)?.click()}
+        >
+          {!imageUrl && (
+            <div className="flex items-center justify-center h-full">
+              <div className="text-center text-white">
+                <Upload className="w-6 h-6 sm:w-8 sm:h-8 mx-auto mb-2" />
+                <p className="text-xs sm:text-sm">Click to upload banner</p>
+              </div>
+            </div>
+          )}
+          {uploading && (
+            <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div
+          className="w-20 h-20 sm:w-24 sm:h-24 rounded-full overflow-hidden cursor-pointer hover:opacity-80 transition-opacity border-2 border-dashed border-gray-600 hover:border-gray-400 flex items-center justify-center"
+          style={imageUrl ? { border: 'none' } : {}}
+          onClick={() => document.getElementById(inputId)?.click()}
+        >
+          <AvatarImage
+            src={imageUrl}
+            alt="Avatar preview"
+            className="w-full h-full object-cover"
+            fallbackColor={avatarColor}
+            fallbackText={username?.charAt(0).toUpperCase() || '?'}
+          />
+          {uploading && (
+            <div className="absolute inset-0 bg-black/50 flex items-center justify-center rounded-full">
+              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-white"></div>
+            </div>
+          )}
+        </div>
+      )}
+      <input
+        id={inputId}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) handleFileChange(file);
+        }}
+      />
+      {imageUrl && (
+        <button
+          onClick={() => onChange('')}
+          className={`absolute ${type === 'banner' ? 'top-2 right-2' : '-top-1 -right-1'} p-1 bg-red-600 hover:bg-red-700 text-white rounded-full transition-colors`}
+        >
+          <X className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -1,33 +1,159 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { User, Palette, Save } from 'lucide-react';
+import { avatarColors } from '../utils/avatarColors';
+import { AvatarUpload } from './AvatarUpload';
 
 interface ProfileFormProps {
-  initialValues: { username: string; bio?: string };
-  onSubmit: (values: { username: string; bio: string }) => void;
+  initialValues: {
+    username: string;
+    bio?: string;
+    avatar_color?: string;
+    avatar_url?: string;
+    banner_url?: string;
+    userId?: string;
+  };
+  onSubmit: (values: {
+    username: string;
+    bio: string;
+    avatar_color?: string;
+    avatar_url?: string;
+    banner_url?: string;
+  }) => void;
+  saving?: boolean;
+  error?: string | null;
+  success?: boolean;
+  onCancel?: () => void;
 }
 
-export function ProfileForm({ initialValues, onSubmit }: ProfileFormProps) {
-  const [username, setUsername] = useState(initialValues.username);
-  const [bio, setBio] = useState(initialValues.bio || '');
+export function ProfileForm({
+  initialValues,
+  onSubmit,
+  saving = false,
+  error,
+  success,
+  onCancel,
+}: ProfileFormProps) {
+  const [formValues, setFormValues] = useState(initialValues);
+
+  useEffect(() => {
+    setFormValues(initialValues);
+  }, [initialValues]);
 
   return (
-    <form onSubmit={e => { e.preventDefault(); onSubmit({ username, bio }); }}>
-      <label>
-        Username
-        <input
-          aria-label="username"
-          value={username}
-          onChange={e => setUsername(e.target.value)}
+    <div className="space-y-4 sm:space-y-6">
+      {/* Banner Upload */}
+      <div>
+        <label className="block text-sm font-medium text-gray-200 mb-2">Banner Image</label>
+        <AvatarUpload
+          userId={initialValues.userId || ''}
+          type="banner"
+          imageUrl={formValues.banner_url || ''}
+          onChange={(url) => setFormValues({ ...formValues, banner_url: url })}
         />
-      </label>
-      <label>
-        Bio
+      </div>
+
+      {/* Avatar Upload */}
+      <div>
+        <label className="block text-sm font-medium text-gray-200 mb-2">Profile Picture</label>
+        <div className="flex flex-col sm:flex-row items-center gap-4">
+          <AvatarUpload
+            userId={initialValues.userId || ''}
+            type="avatar"
+            imageUrl={formValues.avatar_url || ''}
+            avatarColor={formValues.avatar_color}
+            username={formValues.username}
+            onChange={(url) => setFormValues({ ...formValues, avatar_url: url })}
+          />
+          <div className="flex-1">
+            <p className="text-xs sm:text-sm text-gray-300 mb-2 text-center sm:text-left">Click the avatar to upload a custom image</p>
+            <p className="text-xs text-gray-400 text-center sm:text-left">Recommended: Square image, max 5MB</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Username */}
+      <div>
+        <label className="block text-sm font-medium text-gray-200 mb-2">Username</label>
+        <div className="relative">
+          <User className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
+          <input
+            type="text"
+            value={formValues.username}
+            onChange={(e) => setFormValues({ ...formValues, username: e.target.value })}
+            className="w-full pl-10 pr-4 py-3 bg-gray-700 border border-gray-600 text-white rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all duration-200 placeholder-gray-400"
+            placeholder="Enter username"
+            maxLength={30}
+            aria-label="username"
+          />
+        </div>
+      </div>
+
+      {/* Bio */}
+      <div>
+        <label className="block text-sm font-medium text-gray-200 mb-2">Bio</label>
         <textarea
+          value={formValues.bio || ''}
+          onChange={(e) => setFormValues({ ...formValues, bio: e.target.value })}
+          className="w-full px-4 py-3 bg-gray-700 border border-gray-600 text-white rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all duration-200 placeholder-gray-400 resize-none"
+          placeholder="Tell us about yourself..."
+          rows={2}
+          maxLength={200}
           aria-label="bio"
-          value={bio}
-          onChange={e => setBio(e.target.value)}
         />
-      </label>
-      <button type="submit">Save</button>
-    </form>
+        <p className="text-xs text-gray-400 mt-1">{(formValues.bio || '').length}/200 characters</p>
+      </div>
+
+      {/* Avatar Color */}
+      <div>
+        <label className="block text-sm font-medium text-gray-200 mb-2">
+          <Palette className="inline w-4 h-4 mr-1" /> Avatar Color
+        </label>
+        <div className="grid grid-cols-4 sm:grid-cols-6 gap-2 sm:gap-3">
+          {avatarColors.map((color) => (
+            <button
+              key={color}
+              onClick={() => setFormValues({ ...formValues, avatar_color: color })}
+              className={`w-10 h-10 sm:w-12 sm:h-12 rounded-full border-2 transition-all ${
+                formValues.avatar_color === color ? 'border-white scale-110' : 'border-gray-600 hover:border-gray-400'
+              }`}
+              style={{ backgroundColor: color }}
+            />
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-red-900/50 border border-red-700 text-red-200 px-4 py-3 rounded-lg text-sm">{error}</div>
+      )}
+      {success && (
+        <div className="bg-green-900/50 border border-green-700 text-green-200 px-4 py-3 rounded-lg text-sm">Profile updated successfully!</div>
+      )}
+
+      <div className="flex flex-col sm:flex-row gap-3 pt-4">
+        <button
+          onClick={onCancel}
+          className="flex-1 px-4 py-3 bg-gray-700 text-white rounded-lg hover:bg-gray-600 transition-colors order-2 sm:order-1"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={() => onSubmit(formValues)}
+          disabled={saving}
+          className="flex-1 bg-gradient-to-r from-blue-600 to-purple-600 text-white py-3 px-6 rounded-lg font-medium hover:from-blue-700 hover:to-purple-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-800 transition-all duration-200 transform hover:scale-[1.02] active:scale-[0.98] shadow-lg disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none order-1 sm:order-2"
+        >
+          {saving ? (
+            <div className="flex items-center justify-center">
+              <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></div>
+              Saving...
+            </div>
+          ) : (
+            <div className="flex items-center justify-center gap-2">
+              <Save className="w-5 h-5" />
+              Save Changes
+            </div>
+          )}
+        </button>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- create `AvatarUpload` component to handle image uploads
- enhance `ProfileForm` with avatar/banner inputs and color picker
- simplify `UserProfile` modal to use new components

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a1b9f90d8832783fe520f1b1a8f20