### PR TITLE
Fix DM refresh on page focus

### DIFF
--- a/src/__tests__/RootRefresh.test.tsx
+++ b/src/__tests__/RootRefresh.test.tsx
@@ -11,6 +11,7 @@ beforeEach(async () => {
 });
 import * as auth from '../hooks/useAuth';
 import * as messages from '../hooks/useMessages';
+import * as dms from '../hooks/useDirectMessages';
 import * as presence from '../utils/updatePresence';
 
 import '@testing-library/jest-dom';
@@ -31,6 +32,7 @@ jest.mock('../lib/supabase', () => ({
 test('focus triggers refresh without reload', () => {
   const authSpy = jest.spyOn(auth, 'triggerAuthRefresh').mockImplementation(() => Promise.resolve());
   const msgSpy = jest.spyOn(messages, 'triggerMessagesRefresh').mockImplementation(() => {});
+  const dmSpy = jest.spyOn(dms, 'triggerDMsRefresh').mockImplementation(() => {});
   const presSpy = jest.spyOn(presence, 'updatePresence').mockImplementation(() => Promise.resolve());
 
   render(<Root />);
@@ -39,12 +41,14 @@ test('focus triggers refresh without reload', () => {
 
   expect(authSpy).toHaveBeenCalled();
   expect(msgSpy).toHaveBeenCalled();
+  expect(dmSpy).toHaveBeenCalled();
   expect(presSpy).toHaveBeenCalled();
 });
 
 test('visibility change triggers refresh', () => {
   const authSpy = jest.spyOn(auth, 'triggerAuthRefresh').mockImplementation(() => Promise.resolve());
   const msgSpy = jest.spyOn(messages, 'triggerMessagesRefresh').mockImplementation(() => {});
+  const dmSpy = jest.spyOn(dms, 'triggerDMsRefresh').mockImplementation(() => {});
   const presSpy = jest.spyOn(presence, 'updatePresence').mockImplementation(() => Promise.resolve());
 
   render(<Root />);
@@ -54,5 +58,6 @@ test('visibility change triggers refresh', () => {
 
   expect(authSpy).toHaveBeenCalled();
   expect(msgSpy).toHaveBeenCalled();
+  expect(dmSpy).toHaveBeenCalled();
   expect(presSpy).toHaveBeenCalled();
 });

--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -1,4 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
+
+let externalDMRefresh: (() => void) | null = null;
+
+export function triggerDMsRefresh() {
+  externalDMRefresh?.();
+}
 import { supabase } from '../lib/supabase';
 import { updatePresence } from '../utils/updatePresence';
 
@@ -97,10 +103,21 @@ export function useDirectMessages(currentUserId: string) {
     }
   }, []);
 
-  useEffect(() => {
+  const refresh = () => {
     fetchUsers();
     fetchConversations();
-  }, [fetchUsers, fetchConversations]);
+  };
+
+  useEffect(() => {
+    externalDMRefresh = refresh;
+    refresh();
+
+    return () => {
+      if (externalDMRefresh === refresh) {
+        externalDMRefresh = null;
+      }
+    };
+  }, [refresh]);
 
   return {
     users,
@@ -110,6 +127,7 @@ export function useDirectMessages(currentUserId: string) {
     fetchConversations,
     fetchConversationMessages,
     setConversations,
+    refresh,
   };
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { ToastProvider } from './components/Toast';
 import './index.css';
 import { triggerAuthRefresh } from './hooks/useAuth';
 import { triggerMessagesRefresh } from './hooks/useMessages';
+import { triggerDMsRefresh } from './hooks/useDirectMessages';
 import { updatePresence } from './utils/updatePresence';
 
 // Component responsible for setting up focus/visibility event listeners.
@@ -13,6 +14,7 @@ export function Root() {
     const handleRefresh = () => {
       triggerAuthRefresh();
       triggerMessagesRefresh();
+      triggerDMsRefresh();
       updatePresence();
     };
 


### PR DESCRIPTION
## Summary
- expose `triggerDMsRefresh` from `useDirectMessages`
- refresh direct message data when the app regains focus or becomes visible
- adjust RootRefresh tests for the new behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a1d9b5e8c8327923b2414beb419c2