### PR TITLE
Bugfix: keep input active on page blur

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ function App() {
   const {
     messages,
     loading,
+    sending,
     error,
     sendMessage,
     fetchOlderMessages,
@@ -163,9 +164,9 @@ function App() {
         activeUserIds={activeUserIds}
       />
 
-      <MessageInput 
+      <MessageInput
         onSendMessage={handleSendMessage}
-        disabled={loading}
+        disabled={sending}
       />
 
       {previewUserId && (

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -15,6 +15,7 @@ export function useMessages(userId: string | null) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingOlder, setLoadingOlder] = useState(false);
+  const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(true);
 
@@ -179,6 +180,7 @@ export function useMessages(userId: string | null) {
     avatarUrl?: string | null
   ) => {
     try {
+      setSending(true);
       const { error } = await supabase.from('messages').insert({
         content,
         user_name: userName,
@@ -192,6 +194,8 @@ export function useMessages(userId: string | null) {
       await supabase.rpc('update_user_last_active');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to send message');
+    } finally {
+      setSending(false);
     }
   };
 
@@ -199,6 +203,7 @@ export function useMessages(userId: string | null) {
   return {
     messages,
     loading,
+    sending,
     error,
     sendMessage,
     fetchOlderMessages,


### PR DESCRIPTION
## Summary
- avoid disabling the main chat input when messages refresh
- track sending state separately in `useMessages`

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a20536c888327a8d778a14add60a7