### PR TITLE
Fix group chat input disabled state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -164,9 +164,9 @@ function App() {
         activeUserIds={activeUserIds}
       />
 
-      <MessageInput 
+      <MessageInput
         onSendMessage={handleSendMessage}
-        disabled={loading}
+        disabled={loading && messages.length === 0}
       />
 
       {previewUserId && (


### PR DESCRIPTION
## Summary
- enable message input even when loading after initial fetch

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a219f8768832796939b1bcf704a41