### PR TITLE
Handle RPC errors in updatePresence

### DIFF
--- a/src/utils/updatePresence.ts
+++ b/src/utils/updatePresence.ts
@@ -1,5 +1,10 @@
 import { supabase } from '../lib/supabase';
 
 export async function updatePresence(): Promise<void> {
-  await supabase.rpc('update_user_last_active');
+  try {
+    const { error } = await supabase.rpc('update_user_last_active');
+    if (error) throw error;
+  } catch (err) {
+    console.error('Failed to update presence:', err);
+  }
 }


### PR DESCRIPTION
## Summary
- catch failures when updating presence and log them

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a2460cf888327af509e51a1b0435b