### PR TITLE
Improve DM error handling

### DIFF
--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -3,6 +3,7 @@ import { MessageSquare, Send, X, ArrowLeft } from 'lucide-react';
 import { AvatarImage } from './AvatarImage';
 import { ContactSidebar } from './dms/ContactSidebar';
 import { DMMessageItem } from './dms/DMMessageItem';
+import { ErrorMessage } from './ErrorMessage';
 import { useDirectMessages } from '../hooks/useDirectMessages';
 import { supabase } from '../lib/supabase';
 import { updatePresence } from '../utils/updatePresence';
@@ -61,7 +62,7 @@ interface DMsPageProps {
 }
 
 export function DMsPage({ currentUser, onUserClick, unreadConversations = [], onConversationOpen, initialConversationId, onBackToGroupChat, activeUserIds }: DMsPageProps) {
-  const { users, conversations, loading, fetchConversationMessages, setConversations } = useDirectMessages(currentUser.id);
+  const { users, conversations, loading, fetchConversationMessages, setConversations, error, refresh } = useDirectMessages(currentUser.id);
   const [selectedConversation, setSelectedConversation] = useState<DMConversation | null>(null);
   const [newMessage, setNewMessage] = useState('');
   const ensureConnection = () => {
@@ -477,6 +478,12 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
       avatar_color: '#3B82F6'
     };
   };
+
+  if (error) {
+    return (
+      <ErrorMessage message={error} onRetry={refresh} />
+    );
+  }
 
 
 

--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -46,6 +46,7 @@ export function useDirectMessages(currentUserId: string) {
   const [users, setUsers] = useState<User[]>([]);
   const [conversations, setConversations] = useState<DMConversation[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const fetchUsers = useCallback(async () => {
     try {
@@ -60,6 +61,7 @@ export function useDirectMessages(currentUserId: string) {
       await updatePresence();
     } catch (err) {
       console.error('Error fetching users:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load users');
     }
   }, [currentUserId]);
 
@@ -78,6 +80,7 @@ export function useDirectMessages(currentUserId: string) {
       await updatePresence();
     } catch (err) {
       console.error('Error fetching conversations:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load conversations');
     } finally {
       setLoading(false);
     }
@@ -99,6 +102,7 @@ export function useDirectMessages(currentUserId: string) {
       return data || [];
     } catch (err) {
       console.error('Error fetching DM messages:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load messages');
       return [] as DMMessage[];
     }
   }, []);
@@ -128,6 +132,7 @@ export function useDirectMessages(currentUserId: string) {
     fetchConversationMessages,
     setConversations,
     refresh,
+    error,
   };
 }
 


### PR DESCRIPTION
## Summary
- surface errors when fetching DM contacts
- display an error message in the DM page if data fails to load

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a2352543c8327ad4c17e607bdcd68