### PR TITLE
Handle page return event

### DIFF
--- a/src/__tests__/RootRefresh.test.tsx
+++ b/src/__tests__/RootRefresh.test.tsx
@@ -45,6 +45,22 @@ test('focus triggers refresh without reload', () => {
   expect(presSpy).toHaveBeenCalled();
 });
 
+test('pageshow triggers refresh', () => {
+  const authSpy = jest.spyOn(auth, 'triggerAuthRefresh').mockImplementation(() => Promise.resolve());
+  const msgSpy = jest.spyOn(messages, 'triggerMessagesRefresh').mockImplementation(() => {});
+  const dmSpy = jest.spyOn(dms, 'triggerDMsRefresh').mockImplementation(() => {});
+  const presSpy = jest.spyOn(presence, 'updatePresence').mockImplementation(() => Promise.resolve());
+
+  render(<Root />);
+
+  window.dispatchEvent(new Event('pageshow'));
+
+  expect(authSpy).toHaveBeenCalled();
+  expect(msgSpy).toHaveBeenCalled();
+  expect(dmSpy).toHaveBeenCalled();
+  expect(presSpy).toHaveBeenCalled();
+});
+
 test('visibility change triggers refresh', () => {
   const authSpy = jest.spyOn(auth, 'triggerAuthRefresh').mockImplementation(() => Promise.resolve());
   const msgSpy = jest.spyOn(messages, 'triggerMessagesRefresh').mockImplementation(() => {});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,10 +25,12 @@ export function Root() {
     };
 
     window.addEventListener('focus', handleRefresh);
+    window.addEventListener('pageshow', handleRefresh);
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
       window.removeEventListener('focus', handleRefresh);
+      window.removeEventListener('pageshow', handleRefresh);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, []);


### PR DESCRIPTION
## Summary
- ensure auth refresh and presence update fire when returning to the page
- test that the new `pageshow` event refreshes the app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a29b59f048327bc52b44d0e53bf88