### PR TITLE
Fix message send timeout

### DIFF
--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -224,21 +224,16 @@ export function useMessages(userId: string | null) {
       timestamp: new Date().toISOString()
     });
 
-    // Quick auth check with timeout
-    console.log('🔐 [sendMessage] Quick auth check');
+    // Quick auth check without aggressive timeout
+    console.log('🔐 [sendMessage] Checking auth session');
     try {
-      const authPromise = supabase.auth.getSession();
-      const timeoutPromise = new Promise((_, reject) => 
-        setTimeout(() => reject(new Error('Auth check timeout')), 2000)
-      );
-      
-      const { data: { session } } = await Promise.race([authPromise, timeoutPromise]) as any;
+      const { data: { session } } = await supabase.auth.getSession();
       console.log('📋 [sendMessage] Auth check result:', {
         hasSession: !!session,
         userId: session?.user?.id
       });
     } catch (authErr) {
-      console.warn('⚠️ [sendMessage] Auth check failed/timed out, proceeding anyway:', authErr);
+      console.warn('⚠️ [sendMessage] Auth check failed, proceeding anyway:', authErr);
     }
 
     const attempt = async () => {
@@ -297,11 +292,7 @@ export function useMessages(userId: string | null) {
         console.warn('⚠️ [sendMessage] Second attempt failed, trying auth refresh:', err2);
         try {
           console.log('🔐 [sendMessage] Refreshing auth session');
-          const refreshPromise = supabase.auth.refreshSession();
-          const refreshTimeout = new Promise((_, reject) => 
-            setTimeout(() => reject(new Error('Refresh timeout')), 3000)
-          );
-          await Promise.race([refreshPromise, refreshTimeout]);
+          await supabase.auth.refreshSession();
           console.log('🎯 [sendMessage] Third attempt after auth refresh');
           await attempt();
           console.log('🎉 [sendMessage] Third attempt successful');


### PR DESCRIPTION
## Summary
- make auth check in `sendMessage` use a simple `getSession` call
- remove the timeout around the auth refresh step

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a311c601483279f1479495ab46cb0