### PR TITLE
Fix auth check and lint errors

### DIFF
--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -430,13 +430,13 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
     try {
       await attempt();
       return true;
-    } catch (err1) {
+    } catch {
       try {
         supabase.realtime.connect();
         await new Promise((r) => setTimeout(r, 500));
         await attempt();
         return true;
-      } catch (err2) {
+      } catch {
         try {
           await supabase.auth.refreshSession();
           await attempt();

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -226,12 +226,24 @@ export function useMessages(userId: string | null) {
 
     // Quick auth check without aggressive timeout
     console.log('🔐 [sendMessage] Checking auth session');
+    let session = null;
     try {
-      const { data: { session } } = await supabase.auth.getSession();
+      const { data } = await supabase.auth.getSession();
+      session = data.session;
       console.log('📋 [sendMessage] Auth check result:', {
         hasSession: !!session,
         userId: session?.user?.id
       });
+      if (!session) {
+        console.log('🔄 [sendMessage] No session found, refreshing');
+        await supabase.auth.refreshSession();
+        const { data: refreshed } = await supabase.auth.getSession();
+        session = refreshed.session;
+        console.log('📋 [sendMessage] Session after refresh:', {
+          hasSession: !!session,
+          userId: session?.user?.id
+        });
+      }
     } catch (authErr) {
       console.warn('⚠️ [sendMessage] Auth check failed, proceeding anyway:', authErr);
     }


### PR DESCRIPTION
## Summary
- refresh auth session automatically if missing when sending messages
- clean up unused catch variables in DM page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a333c10908327b5d80ec1b69f9dd1