### PR TITLE
Fix auth refresh after returning to page

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
+import { withTimeout } from '../utils/withTimeout';
 import { User } from '@supabase/supabase-js';
 
 export interface AuthUser {
@@ -52,9 +53,10 @@ export function useAuth() {
 
   const refreshSession = async () => {
     console.log('🔄 [useAuth] Refreshing session');
-    
+
     try {
-      const { data: { session } } = await supabase.auth.getSession();
+      await withTimeout(supabase.auth.refreshSession(), 5000);
+      const { data: { session } } = await withTimeout(supabase.auth.getSession(), 5000);
       
       console.log('📋 [useAuth] Session refresh result:', {
         hasSession: !!session,

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -1,18 +1,10 @@
 import { useState, useEffect, useRef } from 'react';
 import { supabase } from '../lib/supabase';
 import { updatePresence } from '../utils/updatePresence';
+import { withTimeout } from '../utils/withTimeout';
 import { Message } from '../types/message';
 
 const PAGE_SIZE = 20;
-
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<T>((_, reject) =>
-      setTimeout(() => reject(new Error('timeout')), timeoutMs)
-    ),
-  ]);
-}
 
 let externalMessagesRefresh: (() => void) | null = null;
 

--- a/src/utils/withTimeout.ts
+++ b/src/utils/withTimeout.ts
@@ -1,0 +1,8 @@
+export function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error('timeout')), timeoutMs)
+    ),
+  ]);
+}


### PR DESCRIPTION
## Summary
- share `withTimeout` helper
- reuse `withTimeout` in `useMessages`
- refresh Supabase session when refocusing the page

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685a7ec759408327ae345804b1cd16d1