### PR TITLE
Add network reconnect for group chat

### DIFF
--- a/src/__tests__/RootRefresh.test.tsx
+++ b/src/__tests__/RootRefresh.test.tsx
@@ -77,3 +77,19 @@ test('visibility change triggers refresh', () => {
   expect(dmSpy).toHaveBeenCalled();
   expect(presSpy).toHaveBeenCalled();
 });
+
+test('online triggers refresh', () => {
+  const authSpy = jest.spyOn(auth, 'triggerAuthRefresh').mockImplementation(() => Promise.resolve());
+  const msgSpy = jest.spyOn(messages, 'triggerMessagesRefresh').mockImplementation(() => {});
+  const dmSpy = jest.spyOn(dms, 'triggerDMsRefresh').mockImplementation(() => {});
+  const presSpy = jest.spyOn(presence, 'updatePresence').mockImplementation(() => Promise.resolve());
+
+  render(<Root />);
+
+  window.dispatchEvent(new Event('online'));
+
+  expect(authSpy).toHaveBeenCalled();
+  expect(msgSpy).toHaveBeenCalled();
+  expect(dmSpy).toHaveBeenCalled();
+  expect(presSpy).toHaveBeenCalled();
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -26,11 +26,13 @@ export function Root() {
 
     window.addEventListener('focus', handleRefresh);
     window.addEventListener('pageshow', handleRefresh);
+    window.addEventListener('online', handleRefresh);
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
       window.removeEventListener('focus', handleRefresh);
       window.removeEventListener('pageshow', handleRefresh);
+      window.removeEventListener('online', handleRefresh);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, []);


### PR DESCRIPTION
## Summary
- re-establish realtime connections when the browser regains internet access
- verify the new `online` event in the Root refresh tests

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_685a819eebcc8327b51024a2102b6800