### PR TITLE
Reconnect Supabase on page show

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,11 +7,13 @@ import { triggerAuthRefresh } from './hooks/useAuth';
 import { triggerMessagesRefresh } from './hooks/useMessages';
 import { triggerDMsRefresh } from './hooks/useDirectMessages';
 import { updatePresence } from './utils/updatePresence';
+import { supabase } from './lib/supabase';
 
 // Component responsible for setting up focus/visibility event listeners.
 export function Root() {
   useEffect(() => {
     const handleRefresh = () => {
+      supabase.realtime.connect();
       triggerAuthRefresh();
       triggerMessagesRefresh();
       triggerDMsRefresh();


### PR DESCRIPTION
## Summary
- reconnect realtime when focus/pageshow events fire so reopened tabs can post messages

## Testing
- `npx tsc -p tsconfig.json`
- `npm run test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a819eebcc8327b51024a2102b6800