### PR TITLE
Implement data refresh on visibility focus

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -44,18 +44,20 @@ export function useAuth() {
     return () => subscription.unsubscribe();
   }, [hasCheckedSession]);
 
+  const refreshSession = async () => {
+    await supabase.auth.refreshSession();
+    const {
+      data: { session }
+    } = await supabase.auth.getSession();
+    if (session?.user) {
+      await fetchUserProfile(session.user);
+    } else {
+      setUser(null);
+      setLoading(false);
+    }
+  };
+
   useEffect(() => {
-    const refreshSession = async () => {
-      const {
-        data: { session }
-      } = await supabase.auth.getSession();
-      if (session?.user) {
-        await fetchUserProfile(session.user);
-      } else {
-        setUser(null);
-        setLoading(false);
-      }
-    };
 
     const handleVisibility = () => {
       if (document.visibilityState === 'visible') {
@@ -115,5 +117,6 @@ export function useAuth() {
     loading,
     signOut,
     updateUser,
+    refreshSession,
   };
 }

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -54,6 +54,12 @@ export function useMessages(userId: string | null) {
     channelRef.current = channel;
   };
 
+  const refresh = () => {
+    if (!userId) return;
+    subscribeToMessages();
+    fetchLatestMessages();
+  };
+
   useEffect(() => {
     if (!userId) return;
 
@@ -70,14 +76,12 @@ export function useMessages(userId: string | null) {
 
     const handleVisibility = () => {
       if (document.visibilityState === 'visible') {
-        subscribeToMessages();
-        fetchLatestMessages();
+        refresh();
       }
     };
 
     const handleFocus = () => {
-      subscribeToMessages();
-      fetchLatestMessages();
+      refresh();
     };
 
     document.addEventListener('visibilitychange', handleVisibility);
@@ -193,6 +197,7 @@ export function useMessages(userId: string | null) {
     sendMessage,
     fetchOlderMessages,
     hasMore,
+    refresh,
   };
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,26 +4,6 @@ import App from './App.tsx';
 import { ToastProvider } from './components/Toast';
 import './index.css';
 
-// Reload the entire page whenever the tab regains focus after being
-// backgrounded. This helps recover when the app becomes flaky after a
-// long period of inactivity.
-let hasFocusedOnce = document.hasFocus();
-
-const reloadOnFocus = () => {
-  if (hasFocusedOnce) {
-    window.location.reload();
-  } else {
-    hasFocusedOnce = true;
-  }
-};
-
-window.addEventListener('focus', reloadOnFocus);
-document.addEventListener('visibilitychange', () => {
-  if (document.visibilityState === 'visible') {
-    reloadOnFocus();
-  }
-});
-
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ToastProvider>


### PR DESCRIPTION
## Summary
- add a `refresh` helper in `useMessages`
- refresh auth session tokens on focus/visibility
- drop page reload behavior in `main.tsx`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685a8a19b5c083278eae83230a13d9be