### PR TITLE
Improve message and auth refresh

### DIFF
--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -70,14 +70,12 @@ export function useMessages(userId: string | null) {
 
     const handleVisibility = () => {
       if (document.visibilityState === 'visible') {
-        subscribeToMessages();
-        fetchLatestMessages();
+        refresh();
       }
     };
 
     const handleFocus = () => {
-      subscribeToMessages();
-      fetchLatestMessages();
+      refresh();
     };
 
     document.addEventListener('visibilitychange', handleVisibility);
@@ -123,6 +121,11 @@ export function useMessages(userId: string | null) {
     } finally {
       setLoading(false);
     }
+  };
+
+  const refresh = () => {
+    subscribeToMessages();
+    fetchLatestMessages();
   };
 
   const fetchOlderMessages = async () => {
@@ -190,6 +193,7 @@ export function useMessages(userId: string | null) {
     messages,
     loading,
     error,
+    refresh,
     sendMessage,
     fetchOlderMessages,
     hasMore,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,26 +4,6 @@ import App from './App.tsx';
 import { ToastProvider } from './components/Toast';
 import './index.css';
 
-// Reload the entire page whenever the tab regains focus after being
-// backgrounded. This helps recover when the app becomes flaky after a
-// long period of inactivity.
-let hasFocusedOnce = document.hasFocus();
-
-const reloadOnFocus = () => {
-  if (hasFocusedOnce) {
-    window.location.reload();
-  } else {
-    hasFocusedOnce = true;
-  }
-};
-
-window.addEventListener('focus', reloadOnFocus);
-document.addEventListener('visibilitychange', () => {
-  if (document.visibilityState === 'visible') {
-    reloadOnFocus();
-  }
-});
-
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ToastProvider>


### PR DESCRIPTION
## Summary
- add `refresh` method to `useMessages` hook and use it for focus/visibility
- expose `refreshSession` from `useAuth` and tidy up effect
- remove page reload listener from `main.tsx`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685a8cba50148327862f798f0e8f94a7