### PR TITLE
Improve contacts reload and avatar caching

### DIFF
--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useCachedImage } from '../hooks/useImageCache';
+
+interface AvatarProps {
+  url?: string | null;
+  alt: string;
+  className?: string;
+  color?: string;
+}
+
+export function Avatar({ url, alt, className = '', color }: AvatarProps) {
+  const src = useCachedImage(url);
+
+  if (!url) {
+    return (
+      <div className={className + ' flex items-center justify-center text-white font-bold'} style={{ backgroundColor: color }}>
+        {alt.charAt(0).toUpperCase()}
+      </div>
+    );
+  }
+
+  return <img src={src || url} alt={alt} className={className} />;
+}

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { LogOut, UserCircle, Users, MessageCircle, Menu, X } from 'lucide-react';
+import { Avatar } from './Avatar';
 
 type PageType = 'group-chat' | 'dms' | 'profile';
 
@@ -134,13 +135,12 @@ export function ChatHeader({ userName, onClearUser, onShowProfile, currentPage, 
           <div className="hidden md:flex absolute inset-0 pointer-events-none items-center justify-center gap-2">
             {activeUsers.map((u) => (
               <div key={u.id} className="w-8 h-8 rounded-full overflow-hidden ring-2 ring-gray-700">
-                {u.avatar_url ? (
-                  <img src={u.avatar_url} alt={u.username} className="w-full h-full object-cover" />
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center text-xs font-medium text-white" style={{ backgroundColor: u.avatar_color }}>
-                    {u.username.charAt(0).toUpperCase()}
-                  </div>
-                )}
+                <Avatar
+                  url={u.avatar_url ?? undefined}
+                  alt={u.username}
+                  color={u.avatar_color}
+                  className="w-full h-full object-cover text-xs font-medium"
+                />
               </div>
             ))}
           </div>

--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -3,6 +3,7 @@ import { Search, MessageSquare, Send, X, Clock, Users, ArrowLeft } from 'lucide-
 import { Smile } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { useToast } from './Toast';
+import { Avatar } from './Avatar';
 
 interface User {
   id: string;
@@ -453,6 +454,12 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
     }
   };
 
+  const handleBackToContacts = useCallback(() => {
+    setSelectedConversation(null);
+    fetchUsers();
+    fetchConversations();
+  }, [fetchUsers, fetchConversations]);
+
   const handleDMReaction = async (messageId: string, emoji: string) => {
     if (!selectedConversation || !currentUser.id || isReacting) return;
 
@@ -620,20 +627,12 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                             <div className="flex items-center gap-3">
                               <div className="relative w-10 h-10 flex-shrink-0 ring-2 ring-gray-600/30 rounded-full">
                                 <div className="w-full h-full rounded-full overflow-hidden">
-                                  {otherUserData.avatar_url ? (
-                                    <img
-                                      src={otherUserData.avatar_url}
-                                      alt={otherUserData.username}
-                                      className="w-full h-full object-cover"
-                                    />
-                                  ) : (
-                                    <div
-                                      className="w-full h-full flex items-center justify-center text-white text-sm font-bold"
-                                      style={{ backgroundColor: otherUserData.avatar_color }}
-                                    >
-                                      {otherUserData.username.charAt(0).toUpperCase()}
-                                    </div>
-                                  )}
+                                  <Avatar
+                                    url={otherUserData.avatar_url}
+                                    alt={otherUserData.username}
+                                    color={otherUserData.avatar_color}
+                                    className="w-full h-full object-cover"
+                                  />
                                 </div>
                                 {activeUserIds.includes(otherUserData.id) && (
                                   <span className="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900 z-10" />
@@ -688,20 +687,12 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                           <div className="flex items-center gap-3">
                             <div className="relative w-10 h-10 flex-shrink-0 ring-2 ring-gray-600/30 rounded-full">
                               <div className="w-full h-full rounded-full overflow-hidden">
-                                {user.avatar_url ? (
-                                  <img
-                                    src={user.avatar_url}
-                                    alt={user.username}
-                                    className="w-full h-full object-cover"
-                                  />
-                                ) : (
-                                  <div
-                                    className="w-full h-full flex items-center justify-center text-white text-sm font-bold"
-                                    style={{ backgroundColor: user.avatar_color }}
-                                  >
-                                    {user.username.charAt(0).toUpperCase()}
-                                  </div>
-                                )}
+                                <Avatar
+                                  url={user.avatar_url}
+                                  alt={user.username}
+                                  color={user.avatar_color}
+                                  className="w-full h-full object-cover"
+                                />
                               </div>
                               {activeUserIds.includes(user.id) && (
                                 <span className="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900 z-10" />
@@ -746,9 +737,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
               <div className="p-4 bg-gradient-to-r from-blue-600/20 to-purple-600/20 border-b border-gray-600/50 flex items-center justify-between backdrop-blur-sm">
                 {/* Mobile back button */}
                 <button
-                  onClick={() => {
-                    setSelectedConversation(null);
-                  }}
+                  onClick={handleBackToContacts}
                   className="md:hidden p-2 text-gray-300 hover:text-white hover:bg-gray-700/60 rounded-xl transition-colors mr-3"
                 >
                   <ArrowLeft className="w-5 h-5" />
@@ -761,20 +750,12 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                       <>
                           <div className="relative w-10 h-10 ring-2 ring-blue-400/30 rounded-full">
                             <div className="w-full h-full rounded-full overflow-hidden">
-                              {otherUserData.avatar_url ? (
-                                <img
-                                  src={otherUserData.avatar_url}
-                                  alt={otherUserData.username}
-                                  className="w-full h-full object-cover"
-                                />
-                              ) : (
-                                <div
-                                  className="w-full h-full flex items-center justify-center text-white text-sm font-bold"
-                                  style={{ backgroundColor: otherUserData.avatar_color }}
-                                >
-                                  {otherUserData.username.charAt(0).toUpperCase()}
-                                </div>
-                              )}
+                              <Avatar
+                                url={otherUserData.avatar_url}
+                                alt={otherUserData.username}
+                                color={otherUserData.avatar_color}
+                                className="w-full h-full object-cover"
+                              />
                             </div>
                             {activeUserIds.includes(otherUserData.id) && (
                               <span className="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900 z-10" />
@@ -791,7 +772,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                   })()}
                 </div>
                 <button
-                  onClick={() => setSelectedConversation(null)}
+                  onClick={handleBackToContacts}
                   className="hidden md:block p-2 text-gray-300 hover:text-white hover:bg-gray-700/60 rounded-xl transition-colors"
                 >
                   <X className="w-5 h-5" />
@@ -830,37 +811,25 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                         >
                           <div className="w-full h-full rounded-full overflow-hidden">
                             {message.sender_id === currentUser.id ? (
-                              currentUserData?.avatar_url ? (
-                                <img
-                                  src={currentUserData.avatar_url}
-                                  alt={currentUser.username}
-                                  className="w-full h-full object-cover"
-                                />
-                              ) : (
-                                <div
-                                  className="w-full h-full flex items-center justify-center text-white text-sm font-bold"
-                                  style={{ backgroundColor: currentUserData?.avatar_color || currentUser.avatar_color }}
-                                >
-                                  {currentUser.username.charAt(0).toUpperCase()}
-                                </div>
-                              )
-                            ) : (() => {
-                              const otherUserData = getOtherUserData(selectedConversation);
-                              return otherUserData.avatar_url ? (
-                                <img
-                                  src={otherUserData.avatar_url}
-                                  alt={otherUserData.username}
-                                  className="w-full h-full object-cover"
-                                />
-                              ) : (
-                                <div
-                                  className="w-full h-full flex items-center justify-center text-white text-sm font-bold"
-                                  style={{ backgroundColor: otherUserData.avatar_color }}
-                                >
-                                  {otherUserData.username.charAt(0).toUpperCase()}
-                                </div>
-                              );
-                            })()}
+                              <Avatar
+                                url={currentUserData?.avatar_url}
+                                alt={currentUser.username}
+                                color={currentUserData?.avatar_color || currentUser.avatar_color}
+                                className="w-full h-full object-cover"
+                              />
+                            ) : (
+                              (() => {
+                                const otherUserData = getOtherUserData(selectedConversation);
+                                return (
+                                  <Avatar
+                                    url={otherUserData.avatar_url}
+                                    alt={otherUserData.username}
+                                    color={otherUserData.avatar_color}
+                                    className="w-full h-full object-cover"
+                                  />
+                                );
+                              })()
+                            )}
                           </div>
                           {activeUserIds.includes(message.sender_id) &&
                             latestMessageByUser.get(message.sender_id) === message.id && (

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -3,6 +3,7 @@ import { Smile } from 'lucide-react';
 import { Message } from '../types/message';
 import { supabase } from '../lib/supabase';
 import { useToast } from './Toast';
+import { Avatar } from './Avatar';
 
 interface MessageBubbleProps {
   message: Message;
@@ -82,30 +83,12 @@ export function MessageBubble({
         title={`View ${message.user_name}'s profile`}
       >
         <div className="w-full h-full rounded-full overflow-hidden">
-          {message.avatar_url ? (
-            <img
-              src={message.avatar_url}
-              alt={message.user_name}
-              className="w-full h-full rounded-full object-cover"
-              onError={(e) => {
-                e.currentTarget.style.display = 'none';
-                const parent = e.currentTarget.parentElement;
-                if (parent) {
-                  const fallback = parent.querySelector('.avatar-fallback') as HTMLElement;
-                  if (fallback) {
-                    fallback.style.display = 'flex';
-                  }
-                }
-              }}
-            />
-          ) : (
-            message.user_name.charAt(0).toUpperCase()
-          )}
-          {message.avatar_url && (
-            <span className="avatar-fallback absolute inset-0 flex items-center justify-center text-white text-xs sm:text-sm font-medium" style={{ display: 'none' }}>
-              {message.user_name.charAt(0).toUpperCase()}
-            </span>
-          )}
+          <Avatar
+            url={message.avatar_url ?? undefined}
+            alt={message.user_name}
+            color={message.avatar_color}
+            className="w-full h-full rounded-full object-cover text-xs sm:text-sm font-medium flex items-center justify-center"
+          />
         </div>
         {isActive && (
           <span className="absolute -top-1 -right-1 w-2 h-2 bg-green-500 rounded-full ring-2 ring-gray-900 z-10" />

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -3,6 +3,7 @@ import { X, User, Mail, Palette, Save, Upload, ArrowLeft } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { ChatHeader } from './ChatHeader';
 import { avatarColors } from '../utils/avatarColors';
+import { Avatar } from './Avatar';
 
 type PageType = 'group-chat' | 'dms' | 'profile';
 
@@ -271,20 +272,12 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
             <div className="px-4 sm:px-6 pt-0 pb-4 sm:pb-6 relative space-y-3 sm:space-y-4 flex-1">
               <div className="flex items-end space-x-4">
                 <div className="-mt-8 sm:-mt-12 w-16 h-16 sm:w-24 sm:h-24 rounded-full overflow-hidden bg-gray-600 ring-4 ring-gray-800 flex-shrink-0">
-                  {profileData.avatar_url ? (
-                    <img
-                      src={profileData.avatar_url}
-                      alt="Avatar"
-                      className="w-full h-full object-cover"
-                    />
-                  ) : (
-                    <div 
-                      className="w-full h-full flex items-center justify-center text-white text-lg sm:text-2xl font-bold"
-                      style={{ backgroundColor: profileData.avatar_color }}
-                    >
-                      {profileData.username.charAt(0).toUpperCase()}
-                    </div>
-                  )}
+                  <Avatar
+                    url={profileData.avatar_url}
+                    alt="Avatar"
+                    color={profileData.avatar_color}
+                    className="w-full h-full object-cover text-lg sm:text-2xl"
+                  />
                 </div>
                 <div className="flex-1">
                   <h2 className="text-lg sm:text-xl font-bold text-white">{profileData.username}</h2>
@@ -407,20 +400,12 @@ export function UserProfile({ user, onClose, onUserUpdate, currentPage, onPageCh
                       style={editData.avatar_url ? { border: 'none' } : {}}
                       onClick={() => document.getElementById('avatar-upload')?.click()}
                     >
-                      {editData.avatar_url ? (
-                        <img
-                          src={editData.avatar_url}
-                          alt="Avatar preview"
-                          className="w-full h-full object-cover"
-                        />
-                      ) : (
-                        <div 
-                          className="w-full h-full flex items-center justify-center text-white text-lg sm:text-xl font-bold"
-                          style={{ backgroundColor: editData.avatar_color }}
-                        >
-                          {editData.username.charAt(0).toUpperCase()}
-                        </div>
-                      )}
+                      <Avatar
+                        url={editData.avatar_url}
+                        alt="Avatar preview"
+                        color={editData.avatar_color}
+                        className="w-full h-full object-cover text-lg sm:text-xl flex items-center justify-center"
+                      />
                       {uploadingAvatar && (
                         <div className="absolute inset-0 bg-black/50 flex items-center justify-center rounded-full">
                           <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-white"></div>

--- a/src/hooks/useImageCache.ts
+++ b/src/hooks/useImageCache.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react';
+
+const memoryCache = new Map<string, string>();
+
+async function fetchAndCache(url: string): Promise<string> {
+  if (memoryCache.has(url)) return memoryCache.get(url)!;
+  const lsKey = `image-cache-${url}`;
+  const cached = localStorage.getItem(lsKey);
+  if (cached) {
+    memoryCache.set(url, cached);
+    return cached;
+  }
+  try {
+    const res = await fetch(url, { cache: 'force-cache' });
+    const blob = await res.blob();
+    const reader = new FileReader();
+    const dataUrl = await new Promise<string>((resolve) => {
+      reader.onloadend = () => resolve(reader.result as string);
+      reader.readAsDataURL(blob);
+    });
+    try {
+      localStorage.setItem(lsKey, dataUrl);
+    } catch {
+      // ignore storage errors (e.g., quota exceeded)
+    }
+    memoryCache.set(url, dataUrl);
+    return dataUrl;
+  } catch {
+    return url;
+  }
+}
+
+export function useCachedImage(url?: string | null) {
+  const [src, setSrc] = useState<string | undefined>(url || undefined);
+
+  useEffect(() => {
+    let active = true;
+    if (!url) {
+      setSrc(undefined);
+      return;
+    }
+    fetchAndCache(url).then((cached) => {
+      if (active) setSrc(cached);
+    });
+    return () => {
+      active = false;
+    };
+  }, [url]);
+
+  return src;
+}


### PR DESCRIPTION
## Summary
- cache avatar images locally using `useImageCache`
- display avatars via new `Avatar` component
- reload contacts when closing a DM conversation

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685acf5b348483279ae766555c09af4b