### PR TITLE
Fix on-screen keyboard closing after sending message

### DIFF
--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -61,6 +61,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
   const [conversations, setConversations] = useState<DMConversation[]>([]);
   const [selectedConversation, setSelectedConversation] = useState<DMConversation | null>(null);
   const [newMessage, setNewMessage] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const draftKey = selectedConversation ? `dmDraft-${selectedConversation.id}` : 'dmDraft';
 
@@ -437,6 +438,8 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
     if (!selectedConversation || !newMessage.trim()) return false;
 
     try {
+      // Keep the input focused so the keyboard remains open
+      inputRef.current?.focus();
       await supabase.rpc('append_dm_message', {
         conversation_id: selectedConversation.id,
         sender_id: currentUser.id,
@@ -445,6 +448,8 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
 
       setNewMessage('');
       localStorage.removeItem(draftKey);
+      // Refocus the input so the keyboard stays open
+      inputRef.current?.focus();
       await updatePresence();
       return true;
     } catch (err) {
@@ -965,6 +970,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                   <div className="relative w-full max-w-2xl min-w-0">
                     <div className="bg-gray-700/80 border border-gray-600/50 rounded-3xl px-3 sm:px-4 pr-12 sm:pr-14 py-2.5 text-white focus-within:ring-2 focus-within:ring-blue-500 shadow-lg transition-all duration-150 backdrop-blur-sm">
                       <input
+                        ref={inputRef}
                         type="text"
                         value={newMessage}
                         onChange={(e) => setNewMessage(e.target.value)}
@@ -980,6 +986,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
                       type="submit"
                       disabled={!newMessage.trim()}
                       className="absolute right-2 sm:right-3 top-1/2 -translate-y-1/2 bg-gradient-to-r from-blue-600 to-purple-600 text-white p-2 sm:p-2.5 rounded-full hover:scale-105 active:scale-95 focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-all shadow-lg"
+                      onMouseDown={(e) => e.preventDefault()}
                     >
                       <Send className="w-4 h-4 sm:w-5 sm:h-5" />
                     </button>

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -24,11 +24,13 @@ export function MessageInput({ onSendMessage, disabled }: MessageInputProps) {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (message.trim() && !disabled) {
-      const success = await onSendMessage(message.trim());
+      const trimmed = message.trim();
+      // Preserve focus so the keyboard stays open while sending
+      textareaRef.current?.focus();
+      const success = await onSendMessage(trimmed);
       if (success) {
         setMessage('');
         localStorage.removeItem('groupChatDraft');
-        // Keep the textarea focused so the keyboard stays open
         textareaRef.current?.focus();
       }
     }
@@ -74,6 +76,7 @@ export function MessageInput({ onSendMessage, disabled }: MessageInputProps) {
             type="submit"
             disabled={!message.trim() || disabled}
             className="absolute right-2 sm:right-3 top-1/2 -translate-y-1/2 bg-gradient-to-r from-blue-600 to-purple-600 text-white p-2 sm:p-2.5 rounded-full hover:scale-105 active:scale-95 focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed transition-all shadow-lg"
+            onMouseDown={(e) => e.preventDefault()}
           >
             <Send className="w-4 h-4 sm:w-5 sm:h-5" />
           </button>


### PR DESCRIPTION
## Summary
- keep textarea focus in MessageInput during send
- prevent send button from stealing focus in MessageInput
- keep input focus in DMsPage when sending messages
- prevent send button from stealing focus in DMsPage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ad01e17a0832795ae6ffbc4acc34f