### PR TITLE
Fix emoji picker overlay on DM exit

### DIFF
--- a/src/components/DMsPage.tsx
+++ b/src/components/DMsPage.tsx
@@ -461,6 +461,7 @@ export function DMsPage({ currentUser, onUserClick, unreadConversations = [], on
 
   const handleBackToContacts = useCallback(() => {
     setSelectedConversation(null);
+    setShowReactionPicker(null);
     fetchUsers();
     fetchConversations();
   }, [fetchUsers, fetchConversations]);


### PR DESCRIPTION
## Summary
- close any open emoji picker when navigating back to contacts

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685ad4fd6c248327b32f5753e4c140d6