### PR TITLE
Fix header visibility on older Safari

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -58,12 +58,16 @@ body {
   }
 }
 
+
 .safe-area-inset-bottom {
   padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+  padding-bottom: max(0.75rem, constant(safe-area-inset-bottom));
 }
+
 
 .safe-area-inset-top {
   padding-top: env(safe-area-inset-top);
+  padding-top: constant(safe-area-inset-top);
 }
 
 


### PR DESCRIPTION
## Summary
- add `constant()` safe area fallback to mobile padding utils

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b020f12088327960cbf11584f95a0