### PR TITLE
Remove unused User interface

### DIFF
--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -8,9 +8,3 @@ export interface Message {
   avatar_url?: string | null;
   reactions?: Record<string, string[]>;
 }
-
-export interface User {
-  id: string;
-  name: string;
-  avatar_color: string;
-}


### PR DESCRIPTION
## Summary
- delete unused `User` interface from message types

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b15eca5e88327bf0fb0b376ab7a3e