### PR TITLE
Remove page reload on focus

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,11 +4,6 @@ import App from './App.tsx';
 import { ToastProvider } from './components/Toast';
 import './index.css';
 
-// Temporary fix: reload the entire page whenever the tab gains focus.
-window.addEventListener('focus', () => {
-  window.location.reload();
-});
-
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ToastProvider>


### PR DESCRIPTION
## Summary
- delete the page reload workaround in `main.tsx`
- rely on hooks to refresh session and messages when the tab gains focus

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b17aa5e908327b7a2ec105140f242