### PR TITLE
Improve active user profiles hook

### DIFF
--- a/src/hooks/useActiveUserProfiles.ts
+++ b/src/hooks/useActiveUserProfiles.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { supabase } from '../lib/supabase';
 
 export interface ActiveUserProfile {
@@ -8,39 +8,84 @@ export interface ActiveUserProfile {
   avatar_color: string;
 }
 
+// Simple in-memory cache for user profiles keyed by user id. Profiles are kept
+// for the lifetime of the application. They are updated whenever a
+// `postgres_changes` event comes through, which effectively invalidates stale
+// data. We do not remove entries when a user goes inactive; keeping them around
+// avoids unnecessary refetches if they become active again later in the same
+// session.
+const profileCache: Record<string, ActiveUserProfile> = {};
+
 export function useActiveUserProfiles(activeUserIds: string[]) {
   const [profiles, setProfiles] = useState<ActiveUserProfile[]>([]);
+  const prevIdsRef = useRef<string[]>([]);
+  const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
+  // Stable key representing the set of active user ids. Sorting ensures we do
+  // not react to changes in array order.
+  const idsKey = useMemo(
+    () => Array.from(new Set(activeUserIds)).sort().join(','),
+    [activeUserIds]
+  );
 
   useEffect(() => {
+    prevIdsRef.current = activeUserIds;
+
+    // Clean up previous subscription before creating a new one.
+    channelRef.current?.unsubscribe();
+    channelRef.current = null;
+
     if (activeUserIds.length === 0) {
       setProfiles([]);
       return;
     }
 
-    const fetchProfiles = async () => {
+    const missingIds = activeUserIds.filter((id) => !profileCache[id]);
+
+    const fetchProfiles = async (ids: string[]) => {
+      if (ids.length === 0) {
+        setProfiles(
+          activeUserIds
+            .map((id) => profileCache[id])
+            .filter((p): p is ActiveUserProfile => Boolean(p))
+        );
+        return;
+      }
+
       const { data, error } = await supabase
         .from('users')
         .select('id, username, avatar_url, avatar_color')
-        .in('id', activeUserIds);
+        .in('id', ids);
       if (error) {
         console.error('Error fetching active user profiles', error);
         setProfiles([]);
       } else {
-        setProfiles(data || []);
+        (data || []).forEach((p) => {
+          profileCache[p.id] = p;
+        });
+        setProfiles(
+          activeUserIds
+            .map((id) => profileCache[id])
+            .filter((p): p is ActiveUserProfile => Boolean(p))
+        );
       }
     };
-    let channel: ReturnType<typeof supabase.channel> | null = null;
+    fetchProfiles(missingIds);
 
-    fetchProfiles();
-
-    channel = supabase
+    channelRef.current = supabase
       .channel('user-profile-updates')
       .on(
         'postgres_changes',
         { event: '*', schema: 'public', table: 'users' },
         (payload) => {
           const updated = payload.new as ActiveUserProfile & { id: string };
-          if (!activeUserIds.includes(updated.id)) return;
+          if (!prevIdsRef.current.includes(updated.id)) return;
+
+          // Update cache and local state with the new profile data.
+          profileCache[updated.id] = {
+            ...(profileCache[updated.id] || {}),
+            ...updated,
+          } as ActiveUserProfile;
+
           setProfiles((prev) => {
             const idx = prev.findIndex((p) => p.id === updated.id);
             if (idx === -1) return prev;
@@ -51,11 +96,12 @@ export function useActiveUserProfiles(activeUserIds: string[]) {
         }
       )
       .subscribe();
-
     return () => {
-      channel?.unsubscribe();
+      channelRef.current?.unsubscribe();
+      channelRef.current = null;
     };
-  }, [activeUserIds]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [idsKey]);
 
   return profiles;
 }


### PR DESCRIPTION
## Summary
- cache user profiles in-memory in `useActiveUserProfiles`
- avoid unnecessary re-fetches/resubscribe using a stable id set key
- update profile cache on realtime updates
- document the cache invalidation strategy

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b1ebce3f4832795cf057bf29d1457