### PR TITLE
Implement LRU-like image cache cleanup

### DIFF
--- a/src/hooks/useImageCache.ts
+++ b/src/hooks/useImageCache.ts
@@ -2,14 +2,36 @@ import { useState, useEffect } from 'react';
 
 const memoryCache = new Map<string, string>();
 
+const CACHE_PREFIX = 'image-cache-';
+const CACHE_KEYS_KEY = `${CACHE_PREFIX}keys`;
+const CACHE_LIMIT = 50;
+
+let cacheKeys: string[] = [];
+
+try {
+  cacheKeys = JSON.parse(localStorage.getItem(CACHE_KEYS_KEY) || '[]');
+} catch {
+  cacheKeys = [];
+}
+
+function saveCacheKeys() {
+  try {
+    localStorage.setItem(CACHE_KEYS_KEY, JSON.stringify(cacheKeys));
+  } catch {
+    // ignore storage errors
+  }
+}
+
 async function fetchAndCache(url: string): Promise<string> {
   if (memoryCache.has(url)) return memoryCache.get(url)!;
-  const lsKey = `image-cache-${url}`;
+
+  const lsKey = `${CACHE_PREFIX}${url}`;
   const cached = localStorage.getItem(lsKey);
   if (cached) {
     memoryCache.set(url, cached);
     return cached;
   }
+
   try {
     const res = await fetch(url, { cache: 'force-cache' });
     const blob = await res.blob();
@@ -18,11 +40,25 @@ async function fetchAndCache(url: string): Promise<string> {
       reader.onloadend = () => resolve(reader.result as string);
       reader.readAsDataURL(blob);
     });
+
     try {
       localStorage.setItem(lsKey, dataUrl);
+      if (!cacheKeys.includes(lsKey)) {
+        cacheKeys.push(lsKey);
+        if (cacheKeys.length > CACHE_LIMIT) {
+          const removeCount = cacheKeys.length - CACHE_LIMIT;
+          const removed = cacheKeys.splice(0, removeCount);
+          removed.forEach((key) => {
+            localStorage.removeItem(key);
+            memoryCache.delete(key.slice(CACHE_PREFIX.length));
+          });
+        }
+        saveCacheKeys();
+      }
     } catch {
       // ignore storage errors (e.g., quota exceeded)
     }
+
     memoryCache.set(url, dataUrl);
     return dataUrl;
   } catch {
@@ -48,4 +84,13 @@ export function useCachedImage(url?: string | null) {
   }, [url]);
 
   return src;
+}
+
+export function clearCache() {
+  cacheKeys.forEach((key) => {
+    localStorage.removeItem(key);
+  });
+  cacheKeys = [];
+  localStorage.removeItem(CACHE_KEYS_KEY);
+  memoryCache.clear();
 }


### PR DESCRIPTION
## Summary
- manage cached image keys and limit cache size
- expose `clearCache` helper to purge images

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b203d6a648327b748978615e3529b