### PR TITLE
Implement throttled draft saving

### DIFF
--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -18,7 +18,10 @@ export function MessageInput({ onSendMessage, disabled }: MessageInputProps) {
   }, []);
 
   useEffect(() => {
-    localStorage.setItem('groupChatDraft', message);
+    const timer = setTimeout(() => {
+      localStorage.setItem('groupChatDraft', message);
+    }, 500);
+    return () => clearTimeout(timer);
   }, [message]);
 
   const handleSubmit = async (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary
- debounce saving message drafts in `MessageInput`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b202d1a2483278bfa96ef477dac37