### PR TITLE
Fix chat scroll restoration after loading older messages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ function App() {
     sendMessage,
     fetchOlderMessages,
     hasMore,
+    loadingOlder,
   } = useMessages(user?.id ?? null);
 
   const activeUserIds = usePresence();
@@ -171,6 +172,7 @@ function App() {
         onRetry={() => window.location.reload()}
         fetchOlderMessages={fetchOlderMessages}
         hasMore={hasMore}
+        loadingOlder={loadingOlder}
         onUserClick={handleUserClick}
         activeUserIds={activeUserIds}
       />

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -193,6 +193,7 @@ export function useMessages(userId: string | null) {
   return {
     messages,
     loading,
+    loadingOlder,
     error,
     refresh,
     sendMessage,


### PR DESCRIPTION
## Summary
- expose `loadingOlder` from `useMessages`
- wire `loadingOlder` through `App` into `ChatArea`
- adjust scroll restoration using `useEffect` when older messages finish loading

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_685b222700008327a36a2e9c8d9c8e62