### PR TITLE
Lazy load profile component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,9 @@ import { AuthForm } from './components/AuthForm';
 import { ChatHeader } from './components/ChatHeader';
 import { ChatArea } from './components/ChatArea';
 import { MessageInput } from './components/MessageInput';
-import { UserProfile } from './components/UserProfile';
+const UserProfile = lazy(() =>
+  import('./components/UserProfile').then((m) => ({ default: m.UserProfile }))
+);
 import { ProfilePreviewModal } from './components/ProfilePreviewModal';
 import { DMNotification } from './components/DMNotification';
 import { useMessages } from './hooks/useMessages';
@@ -62,13 +64,21 @@ function App() {
   // Show profile page if requested
   if (currentPage === 'profile') {
     return (
-      <UserProfile
-        user={user}
-        onClose={() => setCurrentPage('group-chat')}
-        onUserUpdate={updateUser}
-        currentPage={currentPage}
-        onPageChange={setCurrentPage}
-      />
+      <Suspense
+        fallback={
+          <div className="h-screen bg-gray-900">
+            <LoadingSpinner />
+          </div>
+        }
+      >
+        <UserProfile
+          user={user}
+          onClose={() => setCurrentPage('group-chat')}
+          onUserUpdate={updateUser}
+          currentPage={currentPage}
+          onPageChange={setCurrentPage}
+        />
+      </Suspense>
     );
   }
 


### PR DESCRIPTION
## Summary
- lazy load `UserProfile` using React.lazy
- show `LoadingSpinner` inside `Suspense` while the profile component loads

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685b223070dc83278b74b9e45b1818fe